### PR TITLE
Chore: clean package.json and remove invalid type dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.5.4",
-    "@types/html-react-parser": "^3.0.5",
     "eslint": "^8.57.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove the unnecessary `@types/html-react-parser` entry from package.json because the library ships its own types

## Testing
- `npm install` *(fails: 403 Forbidden when downloading @tailwindcss/typography due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cefcc7a3e0832fb5240e95a34e2950