### PR TITLE
Chore: upgrade ESLint to latest Next.js-compatible setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,17 @@
 {
-  "extends": ["next/core-web-vitals"]
+  "extends": ["next/core-web-vitals"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "react", "react-hooks"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.5.4",
-    "eslint": "^8.57.0"
+    "eslint": "^9.0.0",
+    "eslint-config-next": "latest",
+    "eslint-plugin-react": "latest",
+    "eslint-plugin-react-hooks": "latest",
+    "typescript-eslint": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- bump ESLint tooling dependencies to the latest Next.js-compatible versions
- enhance the ESLint configuration to explicitly support TypeScript and React parsing
- keep the lint script aligned with the recommended `next lint` entry point

## Testing
- npm install *(fails: 403 Forbidden fetching @tailwindcss/typography in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cefe7592e8832faf63cd060ff37f54