### PR TITLE
Fix: clean ESLint config and correct Stripe API version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,3 @@
 {
-  "extends": ["next/core-web-vitals"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "react", "react-hooks"],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 2020,
-    "sourceType": "module"
-  },
-  "settings": {
-    "react": {
-      "version": "detect"
-    }
-  }
+  "extends": ["next/core-web-vitals"]
 }

--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -10,7 +10,7 @@ export async function POST() {
   }
 
   try {
-    const stripe = new Stripe(secretKey, { apiVersion: "2024-04-10" });
+    const stripe = new Stripe(secretKey, { apiVersion: "2023-10-16" });
 
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",


### PR DESCRIPTION
## Summary
- simplify ESLint configuration to only extend Next.js core web vitals rules
- update Stripe client initialization to use the 2023-10-16 API version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf0040dda8832fb700ff2c2a24bc0e