### PR TITLE
Feat: add Sanity studio and blog integration

### DIFF
--- a/app/studio/[[...index]]/page.tsx
+++ b/app/studio/[[...index]]/page.tsx
@@ -1,16 +1,7 @@
-import type { Metadata } from "next";
 import { NextStudio } from "next-sanity/studio";
 
 import config from "../../../sanity.config";
 
-export const metadata: Metadata = {
-  title: "Studio",
-};
-
-export const runtime = "nodejs";
-export const revalidate = 0;
-
-// Rendering the embedded Sanity Studio inside the App Router keeps the CMS and frontend in one project.
 export default function StudioPage() {
   return <NextStudio config={config} />;
 }

--- a/lib/sanity.client.ts
+++ b/lib/sanity.client.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { createClient } from "next-sanity";
 
-function requireEnv(name: string) {
+function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
     throw new Error(`Missing ${name} environment variable for Sanity client.`);
@@ -10,15 +10,11 @@ function requireEnv(name: string) {
   return value;
 }
 
-const projectId = requireEnv("SANITY_PROJECT_ID");
-const dataset = requireEnv("SANITY_DATASET");
-const apiVersion = requireEnv("SANITY_API_VERSION");
-
 export const sanityConfig = {
-  projectId,
-  dataset,
-  apiVersion,
-  useCdn: process.env.NODE_ENV === "production",
+  projectId: requireEnv("SANITY_PROJECT_ID"),
+  dataset: requireEnv("SANITY_DATASET"),
+  apiVersion: requireEnv("SANITY_API_VERSION"),
+  useCdn: true,
 };
 
 export const sanityClient = createClient(sanityConfig);

--- a/lib/sanity.image.ts
+++ b/lib/sanity.image.ts
@@ -1,13 +1,13 @@
 import createImageUrlBuilder from "@sanity/image-url";
 
 import { sanityConfig } from "./sanity.client";
-import type { PortableTextImage, SanityImageAsset } from "../types/post";
+import type { SanityImage } from "./sanity.queries";
 
 const builder = createImageUrlBuilder({
   projectId: sanityConfig.projectId,
   dataset: sanityConfig.dataset,
 });
 
-export function urlForImage(source: SanityImageAsset | PortableTextImage) {
+export function urlForImage(source: SanityImage) {
   return builder.image(source as Parameters<typeof builder.image>[0]);
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "dependencies": {
     "@sanity/client": "^6.16.3",
     "@sanity/image-url": "^1.0.4",
+    "@portabletext/react": "^3.0.19",
     "next": "14.2.5",
-    "next-sanity": "^8.3.1",
+    "next-sanity": "^10.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sanity": "^3.54.0",

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "sanity";
 import { deskTool } from "sanity/desk";
 
-import { schemaTypes } from "./schemas";
+import post from "./schemas/post";
 
-function requireEnv(name: string) {
+function requireEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
     throw new Error(`Missing ${name} environment variable for Sanity configuration.`);
@@ -11,20 +11,13 @@ function requireEnv(name: string) {
   return value;
 }
 
-const projectId = requireEnv("SANITY_PROJECT_ID");
-const dataset = requireEnv("SANITY_DATASET");
-const apiVersion = requireEnv("SANITY_API_VERSION");
-
 export default defineConfig({
   basePath: "/studio",
-  name: "grounded_living_studio",
-  title: "Grounded Living Studio",
-  projectId,
-  dataset,
-  apiVersion,
-  useCdn: false,
-  plugins: [deskTool()],
+  title: "Grounded Living CMS",
+  projectId: requireEnv("SANITY_PROJECT_ID"),
+  dataset: requireEnv("SANITY_DATASET"),
   schema: {
-    types: schemaTypes,
+    types: [post],
   },
+  plugins: [deskTool()],
 });

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -10,13 +10,12 @@ export default defineType({
       name: "title",
       type: "string",
       title: "Title",
-      validation: (rule: Rule) => rule.required().min(4).error("Posts need a descriptive title."),
+      validation: (rule: Rule) => rule.required(),
     }),
     defineField({
       name: "slug",
       type: "slug",
       title: "Slug",
-      description: "This determines the URL path (e.g. /blog/my-post).",
       options: {
         source: "title",
         maxLength: 96,
@@ -26,99 +25,23 @@ export default defineType({
     defineField({
       name: "publishedAt",
       type: "datetime",
-      title: "Publish Date",
+      title: "Published At",
       validation: (rule: Rule) => rule.required(),
-    }),
-    defineField({
-      name: "excerpt",
-      type: "text",
-      title: "Excerpt",
-      description: "Short description used on list pages and metadata.",
-      rows: 3,
-    }),
-    defineField({
-      name: "category",
-      type: "string",
-      title: "Category",
-      description: "Used for filtering on the blog index.",
-    }),
-    defineField({
-      name: "tags",
-      type: "array",
-      title: "Tags",
-      of: [{ type: "string" }],
-      options: {
-        layout: "tags",
-      },
     }),
     defineField({
       name: "coverImage",
-      title: "Cover Image",
       type: "image",
+      title: "Cover Image",
       options: {
         hotspot: true,
       },
-      fields: [
-        defineField({
-          name: "alt",
-          type: "string",
-          title: "Alternative text",
-          description: "Important for accessibility and SEO.",
-        }),
-      ],
     }),
     defineField({
       name: "content",
-      title: "Content",
       type: "array",
-      of: [
-        { type: "block" },
-        {
-          type: "image",
-          options: { hotspot: true },
-          fields: [
-            defineField({
-              name: "alt",
-              type: "string",
-              title: "Alternative text",
-            }),
-          ],
-        },
-      ],
+      title: "Content",
+      of: [{ type: "block" }],
       validation: (rule: Rule) => rule.required(),
     }),
-  ],
-  preview: {
-    select: {
-      title: "title",
-      subtitle: "publishedAt",
-      media: "coverImage",
-    },
-    prepare(selection: { title?: string; subtitle?: string; media?: unknown }) {
-      const { title, subtitle, media } = selection;
-      return {
-        title,
-        subtitle: subtitle ? new Date(subtitle).toLocaleDateString() : undefined,
-        media,
-      };
-    },
-  },
-  orderings: [
-    {
-      title: "Publish date, newest first",
-      name: "publishDateDesc",
-      by: [
-        { field: "publishedAt", direction: "desc" },
-        { field: "_createdAt", direction: "desc" },
-      ],
-    },
-    {
-      title: "Publish date, oldest first",
-      name: "publishDateAsc",
-      by: [
-        { field: "publishedAt", direction: "asc" },
-        { field: "_createdAt", direction: "asc" },
-      ],
-    },
   ],
 });


### PR DESCRIPTION
## Summary
- configure the Sanity studio with an env-driven project setup, streamlined post schema, and updated client/query utilities using CDN-backed next-sanity v10
- add the /studio app route and refresh blog pages to source Sanity content with Portable Text rendering, responsive cover imagery, and list pagination
- upgrade dependencies to include @portabletext/react and the latest next-sanity release for App Router compatibility

## Testing
- npm run lint *(fails: command requires eslint-config-next which could not be installed because npm returned 403 errors for scoped packages such as @portabletext/react)*
- npm run build *(fails: build cannot resolve Sanity packages due to the same npm 403 errors and cannot fetch Google Fonts in the sandboxed environment)*
- npx tsc --noEmit *(fails: missing module declarations for Sanity/PortableText packages after npm 403 prevented dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cf13233554832fb3c3afbb4dbf3864