### PR TITLE
Chore: align Next.js, Sanity, and Tailwind for Vercel

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,7 @@
-# Sanity project credentials
+# Sanity project credentials used for both the Next.js app and the embedded Studio.
+NEXT_PUBLIC_SANITY_PROJECT_ID=
+NEXT_PUBLIC_SANITY_DATASET=production
+# Legacy names remain supported for local tooling that still references them.
 SANITY_PROJECT_ID=
 SANITY_DATASET=production
 SANITY_API_VERSION=2024-05-01

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ can spin it up locally in minutes, give editors a welcoming Studio, and ship upd
    ```
 3. **Fill in `.env.local`**
    ```dotenv
-   SANITY_PROJECT_ID=yourProjectId
-   SANITY_DATASET=production
+   NEXT_PUBLIC_SANITY_PROJECT_ID=yourProjectId
+   NEXT_PUBLIC_SANITY_DATASET=production
    SANITY_API_VERSION=2024-05-01
    SANITY_READ_TOKEN= # optional – only required for private datasets or draft previews
    SANITY_REVALIDATE_SECRET=choose-a-long-random-string
@@ -115,7 +115,7 @@ public/             # Static assets (favicons, OG image)
 
 ## 8. Troubleshooting
 
-- **Blank Studio:** Double-check `SANITY_PROJECT_ID` and `SANITY_DATASET`. Without them the Studio renders an empty shell.
+- **Blank Studio:** Double-check `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET`. Without them the Studio renders an empty shell.
 - **Content not updating:** Confirm the webhook is hitting `/api/revalidate` with the correct secret and that your pages use the
   provided revalidation tags.
 - **Image URLs look broken:** Ensure the Sanity dataset is public or provide `SANITY_READ_TOKEN` for private datasets.

--- a/lib/sanity.client.ts
+++ b/lib/sanity.client.ts
@@ -3,8 +3,23 @@ import "server-only";
 import type { ClientConfig } from "@sanity/client";
 import { createClient } from "next-sanity";
 
-const projectId = process.env.SANITY_PROJECT_ID;
-const dataset = process.env.SANITY_DATASET;
+/**
+ * Shared helper that reads Sanity environment variables while supporting both the legacy
+ * server-only names and the new Next.js public variants expected by Vercel.
+ */
+function readSanityEnv(name: "SANITY_PROJECT_ID" | "SANITY_DATASET") {
+  const legacy = process.env[name];
+  const nextPublic = process.env[`NEXT_PUBLIC_${name}` as const];
+
+  if (!legacy && !nextPublic && process.env.NODE_ENV !== "production") {
+    console.warn(`${name} (or NEXT_PUBLIC_${name}) is missing. Sanity clients will be disabled.`);
+  }
+
+  return legacy || nextPublic || "";
+}
+
+const projectId = readSanityEnv("SANITY_PROJECT_ID");
+const dataset = readSanityEnv("SANITY_DATASET") || "production";
 const apiVersion = process.env.SANITY_API_VERSION || "2024-05-01";
 const token = process.env.SANITY_READ_TOKEN;
 

--- a/lib/sanity.image.ts
+++ b/lib/sanity.image.ts
@@ -1,8 +1,11 @@
 import imageUrlBuilder from "@sanity/image-url";
 import type { SanityImageSource } from "@sanity/image-url/lib/types/types";
 
-const projectId = process.env.SANITY_PROJECT_ID;
-const dataset = process.env.SANITY_DATASET;
+/**
+ * Supports both legacy and NEXT_PUBLIC env names so the URL builder works locally and on Vercel.
+ */
+const projectId = process.env.SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.SANITY_DATASET || process.env.NEXT_PUBLIC_SANITY_DATASET;
 
 const builder = projectId && dataset ? imageUrlBuilder({ projectId, dataset }) : null;
 

--- a/package.json
+++ b/package.json
@@ -3,34 +3,46 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "^20.11.0"
+  },
   "scripts": {
+    "// dev": "Starts the Next.js development server with hot reloading for local work.",
     "dev": "next dev",
+    "// build": "Generates an optimized production build.",
     "build": "next build",
+    "// start": "Runs the pre-built production bundle on the configured port.",
     "start": "next start",
+    "// lint": "Validates the codebase with ESLint using Next.js defaults.",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "// studio": "Launches the embedded Sanity Studio together with the Next.js app on an alternate port.",
+    "studio": "next dev --hostname 0.0.0.0 --port 3333",
+    "// typecheck": "Optional script to verify TypeScript types without emitting output.",
+    "typecheck": "tsc --noEmit",
+    "// clean-reinstall": "Run `rm -rf node_modules package-lock.json && npm install` to refresh dependencies."
   },
   "dependencies": {
-    "@sanity/client": "^6.18.0",
-    "@sanity/image-url": "^1.0.2",
-    "next": "15.0.3",
-    "next-sanity": "^9.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "sanity": "^3.60.0",
+    "@sanity/client": "^7.0.1",
+    "@sanity/image-url": "^1.0.3",
+    "next": "^15.5.0",
+    "next-sanity": "^9.3.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "sanity": "^3.61.0",
     "turndown": "^7.2.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.13",
-    "@types/node": "^20.14.2",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "@tailwindcss/typography": "^0.5.15",
+    "@types/node": "^22.7.5",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
     "autoprefixer": "^10.4.20",
-    "eslint": "^8.57.0",
-    "eslint-config-next": "15.0.3",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.7",
-    "typescript": "5.5.4"
+    "eslint": "^9.12.0",
+    "eslint-config-next": "^15.5.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,12 @@
-const config = {
+/**
+ * PostCSS pipeline configured for Tailwind CSS v4.
+ * The Tailwind plugin processes directives while Autoprefixer ensures browser compatibility.
+ */
+module.exports = {
   plugins: {
-    tailwindcss: {},
+    /** Tailwind v4 PostCSS plugin keeps directives colocated with component styles. */
+    '@tailwindcss/postcss': {},
+    /** Autoprefixer adds vendor prefixes for the targeted browserslist. */
     autoprefixer: {},
   },
 };
-
-export default config;

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -5,10 +5,14 @@ import page from "./schemas/page";
 import post from "./schemas/post";
 
 function readEnv(name: string, fallback?: string) {
-  const value = process.env[name];
+  const legacy = process.env[name];
+  const nextPublic = process.env[`NEXT_PUBLIC_${name}`];
+  const value = legacy || nextPublic;
+
   if (!value && process.env.NODE_ENV !== "production") {
-    console.warn(`Missing ${name} for Sanity configuration. Using fallback value.`);
+    console.warn(`Missing ${name} (or NEXT_PUBLIC_${name}) for Sanity configuration. Using fallback value.`);
   }
+
   return value || fallback || "";
 }
 
@@ -16,6 +20,7 @@ const projectId = readEnv("SANITY_PROJECT_ID");
 const dataset = readEnv("SANITY_DATASET", "production");
 
 export default defineConfig({
+  /** Expose the embedded Studio at /studio so Vercel deployments remain self-contained. */
   basePath: "/studio",
   name: "grounded_living_studio",
   title: "Grounded Living Studio",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,13 @@
 import type { Config } from "tailwindcss";
 import typography from "@tailwindcss/typography";
 
+/**
+ * Tailwind configuration scoped to both legacy folders and the new ./src convention
+ * so migrations to the src/ tree are seamless.
+ */
 const config: Config = {
   content: [
+    "./src/**/*.{js,ts,jsx,tsx}",
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./content/**/*.{md,mdx}",
@@ -52,7 +57,10 @@ const config: Config = {
       },
     },
   },
-  plugins: [typography],
+  plugins: [
+    /** Typography plugin keeps long-form content polished out of the box. */
+    typography,
+  ],
 };
 
 export default config;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "// purpose": "Ensure Sanity Studio behaves like an SPA when deployed on Vercel.",
+  "rewrites": [
+    {
+      "// studio": "Redirect nested Studio routes back to the root so the client router can handle them.",
+      "source": "/studio/:path*",
+      "destination": "/studio"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- upgrade the dependency stack to Next.js 15.5, React 19, Sanity v7 tooling, and Tailwind CSS v4 with inline documentation in package.json
- refresh Sanity environment handling and examples so both legacy and NEXT_PUBLIC variables work for Vercel + Studio at /studio
- add deployment plumbing (Tailwind/PostCSS v4 config and SPA rewrite vercel.json) needed for clean Vercel builds

## Testing
- npm install *(fails: npm returned 403 Forbidden while fetching packages from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d0602ea2e4832f89678d42e8a1f1ab