### PR TITLE
Fix: allow Sanity queries to build without env vars

### DIFF
--- a/lib/sanity.client.ts
+++ b/lib/sanity.client.ts
@@ -1,36 +1,66 @@
 import "server-only";
-import { createClient, type ClientConfig } from "next-sanity";
+import { createClient, type ClientConfig, type SanityClient } from "next-sanity";
 
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
-const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || process.env.SANITY_DATASET;
 const apiVersion = process.env.SANITY_API_VERSION || "2024-05-01";
 const token = process.env.SANITY_READ_TOKEN;
 
+const missingEnv: string[] = [];
 if (!projectId) {
-  throw new Error("❌ Missing NEXT_PUBLIC_SANITY_PROJECT_ID in environment variables");
+  missingEnv.push("NEXT_PUBLIC_SANITY_PROJECT_ID");
 }
 if (!dataset) {
-  throw new Error("❌ Missing NEXT_PUBLIC_SANITY_DATASET in environment variables");
+  missingEnv.push("NEXT_PUBLIC_SANITY_DATASET");
 }
 
-const config: ClientConfig = {
-  projectId,
-  dataset,
-  apiVersion,
-  useCdn: process.env.NODE_ENV === "production" && !token,
-  perspective: "published",
-  token,
-};
+const config: ClientConfig | null = missingEnv.length === 0
+  ? {
+      projectId: projectId!,
+      dataset: dataset!,
+      apiVersion,
+      useCdn: process.env.NODE_ENV === "production" && !token,
+      perspective: "published",
+      token,
+    }
+  : null;
 
-export const client = createClient(config);
+const client: SanityClient | null = config ? createClient(config) : null;
+
+if (!client) {
+  const formattedList = missingEnv.join(", ");
+  const message = `❌ Missing Sanity environment variables: ${formattedList}. Content queries will use provided fallbacks.`;
+  if (process.env.NODE_ENV === "production") {
+    console.error(message);
+  } else {
+    console.warn(message);
+  }
+}
+
+export type FetchSanityOptions<T> = {
+  revalidate?: number;
+  tags?: string[];
+  fallback?: T;
+};
 
 export async function fetchSanity<T>(
   query: string,
   params: Record<string, unknown> = {},
-  options: { revalidate?: number; tags?: string[] } = {}
+  options: FetchSanityOptions<T> = {},
 ): Promise<T> {
+  const { revalidate, tags, fallback } = options;
+
+  if (!client) {
+    if (fallback !== undefined) {
+      // When environment variables are missing during local builds/tests we fall back to caller-provided data
+      // so the site can render without hard failing. Production deploys should provide real credentials.
+      return fallback;
+    }
+    throw new Error("Sanity client is unavailable and no fallback value was provided for fetchSanity().");
+  }
+
   return client.fetch<T>(query, params, {
     cache: "force-cache",
-    next: { revalidate: options.revalidate ?? 60, tags: options.tags ?? ["sanity"] },
+    next: { revalidate: revalidate ?? 60, tags: tags ?? ["sanity"] },
   });
 }

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -71,7 +71,7 @@ export async function getPosts(): Promise<PostListItem[]> {
   const result = await fetchSanity<PostListItem[]>(
     `*[_type == "post" && defined(slug.current) && defined(publishedAt)] | order(publishedAt desc) { ${postListFields} }`,
     {},
-    { tags: ["sanity", "posts"], revalidate: 60 },
+    { tags: ["sanity", "posts"], revalidate: 60, fallback: [] },
   );
   return result ?? [];
 }
@@ -80,7 +80,7 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
   const result = await fetchSanity<Post | null>(
     `*[_type == "post" && slug.current == $slug][0] { ${postDetailFields} }`,
     { slug },
-    { tags: ["sanity", "posts", `post:${slug}`], revalidate: 60 },
+    { tags: ["sanity", "posts", `post:${slug}`], revalidate: 60, fallback: null },
   );
   return result ?? null;
 }
@@ -95,7 +95,7 @@ export async function getPageBySlug(slug: string): Promise<Page | null> {
       ${imageSelection}
     }`,
     { slug },
-    { tags: ["sanity", "pages", `page:${slug}`], revalidate: 60 },
+    { tags: ["sanity", "pages", `page:${slug}`], revalidate: 60, fallback: null },
   );
   return result ?? null;
 }


### PR DESCRIPTION
## Summary
- create a Sanity client helper that falls back to caller-provided data when environment variables are missing so builds do not crash
- update post and page queries to supply safe fallbacks while preserving ISR settings

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e3f9c164832f84f1cbd72ee9ec83