### PR TITLE
Fix: hash studio session cookie and client-only dashboard render

### DIFF
--- a/pages/studio/login.tsx
+++ b/pages/studio/login.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { STUDIO_COOKIE_NAME } from "@/lib/studio/constants";
+import { getExpectedHash } from "@/lib/studio/security";
 
 const parseCookieValue = (cookieHeader: string | undefined, key: string) => {
   if (!cookieHeader) {
@@ -109,8 +110,9 @@ const StudioLoginPage = () => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const sessionCookie = parseCookieValue(context.req.headers.cookie, STUDIO_COOKIE_NAME);
+  const expectedHash = getExpectedHash();
 
-  if (sessionCookie === "authenticated") {
+  if (expectedHash && sessionCookie === expectedHash) {
     return {
       redirect: {
         destination: "/studio",


### PR DESCRIPTION
## Summary
- hash the studio admin session cookie and reuse the same value wherever we verify access
- dynamically load the studio dashboard on the client to avoid SSR hook crashes and surface a safe fallback loader

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d611dea318832fb0787d3d90cb229d