### PR TITLE
Feat: harden blog SEO metadata and canonical routing

### DIFF
--- a/lib/contentfulManagement.ts
+++ b/lib/contentfulManagement.ts
@@ -152,6 +152,7 @@ export interface BlogPostSummary extends EntrySummary {
   excerpt?: string | null;
   datePublished?: string | null;
   coverImage?: StudioAsset | null;
+  seoTitle?: string | null;
   seoDescription?: string | null;
 }
 
@@ -219,6 +220,7 @@ function mapBlogPostSummary(entry: ManagementEntry): BlogPostSummary {
     slug: getLocalizedField<string>(entry.fields, "slug"),
     excerpt: getLocalizedField<string>(entry.fields, "excerpt"),
     datePublished: getLocalizedField<string>(entry.fields, "date-published"),
+    seoTitle: getLocalizedField<string>(entry.fields, "seoTitle"),
     seoDescription: getLocalizedField<string>(entry.fields, "seo-description"),
     createdAt: entry.sys.createdAt ?? new Date().toISOString(),
     updatedAt: entry.sys.updatedAt ?? new Date().toISOString(),

--- a/lib/seo/post.ts
+++ b/lib/seo/post.ts
@@ -1,0 +1,322 @@
+import type { BlogPost } from "@/types/contentful";
+import { metaFromRichTextExcerpt } from "@/lib/seo/meta";
+import { richTextToPlainText } from "@/lib/richtext";
+import type { JsonLdObject } from "./schema";
+
+import seoConfig from "../../next-seo.config";
+
+const MAX_TITLE_LENGTH = 65;
+const MAX_DESCRIPTION_LENGTH = 155;
+const DEFAULT_AUTHOR = "Grounded Living";
+const FALLBACK_IMAGE_URL = new URL("/og-image.svg", seoConfig.siteUrl).toString();
+
+interface PostMetaImage {
+  url: string;
+  alt: string;
+  width: number;
+  height: number;
+}
+
+export interface PostMeta {
+  title: string;
+  description: string;
+  image: PostMetaImage;
+  publishedTime: string | null;
+  modifiedTime: string | null;
+  authorName: string;
+}
+
+interface ArticleJsonLdOptions {
+  canonicalUrl: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  breadcrumb?: JsonLdObject | null;
+  authorName: string;
+  publishedTime?: string | null;
+  modifiedTime?: string | null;
+}
+
+interface RecipeJsonLdOptions {
+  canonicalUrl: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  authorName: string;
+  datePublished?: string | null;
+}
+
+export function resolvePostMeta(post: BlogPost): PostMeta {
+  const baseTitle = pickFirst([
+    collapseWhitespace(post.seoTitle),
+    collapseWhitespace(post.title),
+    seoConfig.defaultTitle,
+  ]);
+  const title = truncateAtBoundary(baseTitle, MAX_TITLE_LENGTH);
+
+  const description = truncateAtBoundary(
+    pickFirst([
+      collapseWhitespace(post.seoDescription),
+      collapseWhitespace(post.excerpt),
+      collapseWhitespace(metaFromRichTextExcerpt(post.content, MAX_DESCRIPTION_LENGTH)),
+      seoConfig.defaultDescription,
+    ]),
+    MAX_DESCRIPTION_LENGTH,
+  );
+
+  const image = resolvePostImage(post);
+  const authorName = pickFirst([collapseWhitespace(post.author?.name), DEFAULT_AUTHOR]);
+  const publishedTime = post.datePublished ?? null;
+
+  return {
+    title,
+    description,
+    image,
+    authorName,
+    publishedTime,
+    modifiedTime: publishedTime,
+  } satisfies PostMeta;
+}
+
+export function buildArticleJsonLd(post: BlogPost, options: ArticleJsonLdOptions): JsonLdObject {
+  const publishedTime = options.publishedTime ?? post.datePublished ?? new Date().toISOString();
+  const modifiedTime = options.modifiedTime ?? publishedTime;
+
+  const schema: JsonLdObject = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: options.title,
+    description: options.description,
+    url: options.canonicalUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": options.canonicalUrl,
+    },
+    datePublished: publishedTime,
+    dateModified: modifiedTime,
+    isAccessibleForFree: true,
+    author: {
+      "@type": "Person",
+      name: options.authorName || DEFAULT_AUTHOR,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: DEFAULT_AUTHOR,
+      logo: {
+        "@type": "ImageObject",
+        url: FALLBACK_IMAGE_URL,
+      },
+    },
+  } satisfies JsonLdObject;
+
+  if (options.imageUrl) {
+    schema.image = [options.imageUrl];
+  }
+
+  if (options.breadcrumb) {
+    schema.breadcrumb = options.breadcrumb;
+  }
+
+  const plainBody = richTextToPlainText(post.content);
+  if (plainBody) {
+    schema.articleBody = plainBody;
+    const wordCount = plainBody.split(/\s+/).filter(Boolean).length;
+    if (wordCount > 0) {
+      schema.wordCount = wordCount;
+    }
+  }
+
+  return schema;
+}
+
+export function buildRecipeJsonLd(post: BlogPost, options: RecipeJsonLdOptions): JsonLdObject | null {
+  const recipe = post.recipe;
+  if (!recipe) {
+    return null;
+  }
+
+  const ingredients = sanitizeList(recipe.ingredients);
+  const instructions = sanitizeList(recipe.instructions);
+
+  if (ingredients.length === 0 || instructions.length === 0) {
+    return null;
+  }
+
+  const instructionSteps = instructions.map((step, index) => ({
+    "@type": "HowToStep",
+    position: index + 1,
+    text: step,
+  }));
+
+  const schema: JsonLdObject = {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    name: pickFirst([collapseWhitespace(recipe.name), options.title]),
+    description: pickFirst([collapseWhitespace(recipe.description), options.description]),
+    recipeIngredient: ingredients,
+    recipeInstructions: instructionSteps,
+    author: {
+      "@type": "Person",
+      name: options.authorName || DEFAULT_AUTHOR,
+    },
+    mainEntityOfPage: options.canonicalUrl,
+  } satisfies JsonLdObject;
+
+  if (options.imageUrl) {
+    schema.image = [options.imageUrl];
+  }
+
+  const yieldValue = collapseWhitespace(recipe.yield);
+  if (yieldValue) {
+    schema.recipeYield = yieldValue;
+  }
+
+  const prepMinutes = parseDurationMinutes(recipe.prepTime);
+  const cookMinutes = parseDurationMinutes(recipe.cookTime);
+  const totalMinutes =
+    parseDurationMinutes(recipe.totalTime) ?? ((prepMinutes ?? 0) + (cookMinutes ?? 0) || undefined);
+
+  const prepDuration = minutesToDuration(prepMinutes);
+  if (prepDuration) {
+    schema.prepTime = prepDuration;
+  }
+
+  const cookDuration = minutesToDuration(cookMinutes);
+  if (cookDuration) {
+    schema.cookTime = cookDuration;
+  }
+
+  const totalDuration = minutesToDuration(totalMinutes);
+  if (totalDuration) {
+    schema.totalTime = totalDuration;
+  }
+
+  if (options.datePublished) {
+    schema.datePublished = options.datePublished;
+  }
+
+  return schema;
+}
+
+function collapseWhitespace(value?: string | null): string {
+  return typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+}
+
+function pickFirst<T extends string>(values: T[]): T {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return values[values.length - 1];
+}
+
+function truncateAtBoundary(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  const slice = trimmed.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(" ");
+  const base = lastSpace > Math.floor(maxLength * 0.6) ? slice.slice(0, lastSpace) : slice;
+  return `${base.replace(/[.…]+$/u, "").trimEnd()}…`;
+}
+
+function resolvePostImage(post: BlogPost): PostMetaImage {
+  if (post.coverImage?.url) {
+    const alt = pickFirst([
+      collapseWhitespace(post.coverImage.description),
+      collapseWhitespace(post.coverImage.title),
+      collapseWhitespace(post.title),
+      "Featured image",
+    ]);
+
+    return {
+      url: `${post.coverImage.url}?w=1200&h=630&fit=fill`,
+      alt,
+      width: 1200,
+      height: 630,
+    } satisfies PostMetaImage;
+  }
+
+  return {
+    url: FALLBACK_IMAGE_URL,
+    alt: "Grounded Living cover art",
+    width: 1200,
+    height: 630,
+  } satisfies PostMetaImage;
+}
+
+function sanitizeList(values?: string[] | null): string[] {
+  return (values ?? [])
+    .map((value) => collapseWhitespace(value))
+    .filter((value) => value.length > 0);
+}
+
+function parseDurationMinutes(value: string | number | null | undefined): number | undefined {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) {
+      return undefined;
+    }
+    return Math.round(value);
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^P/i.test(trimmed)) {
+    let minutes = 0;
+    const dayMatch = trimmed.match(/(\d+)D/i);
+    if (dayMatch) {
+      minutes += Number.parseInt(dayMatch[1] ?? "0", 10) * 1440;
+    }
+    const hourMatch = trimmed.match(/(\d+)H/i);
+    if (hourMatch) {
+      minutes += Number.parseInt(hourMatch[1] ?? "0", 10) * 60;
+    }
+    const minuteMatch = trimmed.match(/(\d+)M/i);
+    if (minuteMatch) {
+      minutes += Number.parseInt(minuteMatch[1] ?? "0", 10);
+    }
+    const secondMatch = trimmed.match(/(\d+)S/i);
+    if (secondMatch) {
+      minutes += Math.round(Number.parseInt(secondMatch[1] ?? "0", 10) / 60);
+    }
+    return minutes > 0 ? minutes : undefined;
+  }
+
+  let totalMinutes = 0;
+  const hoursMatch = trimmed.match(/(\d+(?:\.\d+)?)\s*(?:hours?|hrs?|hr|h)\b/i);
+  if (hoursMatch) {
+    totalMinutes += Math.round(Number.parseFloat(hoursMatch[1]) * 60);
+  }
+
+  const minutesMatch = trimmed.match(/(\d+(?:\.\d+)?)\s*(?:minutes?|mins?|min|m)\b/i);
+  if (minutesMatch) {
+    totalMinutes += Math.round(Number.parseFloat(minutesMatch[1]));
+  }
+
+  if (totalMinutes === 0) {
+    const numeric = Number.parseFloat(trimmed);
+    if (!Number.isNaN(numeric)) {
+      totalMinutes = Math.round(numeric);
+    }
+  }
+
+  return totalMinutes > 0 ? totalMinutes : undefined;
+}
+
+function minutesToDuration(minutes?: number): string | undefined {
+  if (!minutes || minutes <= 0) {
+    return undefined;
+  }
+
+  return `PT${minutes}M`;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,54 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import seoConfig from "./next-seo.config";
+
+const canonicalUrlString = process.env.NEXT_PUBLIC_SITE_URL ?? seoConfig.siteUrl;
+let canonicalUrl: URL | null = null;
+try {
+  canonicalUrl = new URL(canonicalUrlString);
+} catch {
+  canonicalUrl = null;
+}
+
+const canonicalHost = canonicalUrl?.host ?? null;
+const canonicalProtocol = canonicalUrl?.protocol ?? null;
+
+const LOCAL_HOST_PATTERNS = [/^localhost(:\d+)?$/i, /^127\.0\.0\.1(:\d+)?$/];
+
+export function middleware(request: NextRequest) {
+  if (!canonicalHost) {
+    return NextResponse.next();
+  }
+
+  const hostHeader = request.headers.get("host");
+  if (!hostHeader) {
+    return NextResponse.next();
+  }
+
+  const normalizedHost = hostHeader.toLowerCase();
+
+  if (normalizedHost === canonicalHost.toLowerCase()) {
+    return NextResponse.next();
+  }
+
+  if (LOCAL_HOST_PATTERNS.some((pattern) => pattern.test(normalizedHost))) {
+    return NextResponse.next();
+  }
+
+  if (process.env.NODE_ENV !== "production" && !normalizedHost.endsWith(".vercel.app")) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  if (canonicalProtocol) {
+    url.protocol = canonicalProtocol;
+  }
+  url.host = canonicalHost;
+
+  return NextResponse.redirect(url, 308);
+}
+
+export const config = {
+  matcher: ["/((?!_next|_vercel|.*\\..*).*)"],
+};

--- a/scripts/lint-content.ts
+++ b/scripts/lint-content.ts
@@ -13,6 +13,8 @@ interface PostSeed {
   content?: string;
   references?: unknown;
   disclosureNeeded?: boolean;
+  seoTitle?: string;
+  seoDescription?: string;
 }
 
 async function loadJsonPosts(): Promise<Array<{ file: string; data: PostSeed }>> {
@@ -45,7 +47,15 @@ function hasInternalLinkCandidate(seed: PostSeed): boolean {
     return true;
   }
 
-  const textSources = [seed.title, seed.description, seed.excerpt, seed.body, seed.content]
+  const textSources = [
+    seed.title,
+    seed.description,
+    seed.excerpt,
+    seed.body,
+    seed.content,
+    seed.seoTitle,
+    seed.seoDescription,
+  ]
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
     .join(" \n")
     .toLowerCase();
@@ -72,6 +82,16 @@ function validatePost(file: string, seed: PostSeed): string[] {
     errors.push("missing description or excerpt");
   } else if (description.length > 160) {
     errors.push(`description exceeds 160 characters (${description.length})`);
+  }
+
+  const seoTitle = typeof seed.seoTitle === "string" ? seed.seoTitle.trim() : "";
+  if (seoTitle.length > 65) {
+    errors.push(`seoTitle exceeds 65 characters (${seoTitle.length})`);
+  }
+
+  const seoDescription = typeof seed.seoDescription === "string" ? seed.seoDescription.trim() : "";
+  if (seoDescription.length > 160) {
+    errors.push(`seoDescription exceeds 160 characters (${seoDescription.length})`);
   }
 
   if (typeof seed.disclosureNeeded !== "boolean") {

--- a/types/contentful.ts
+++ b/types/contentful.ts
@@ -76,12 +76,13 @@ export interface BlogPostSummary {
   excerpt?: string | null;
   coverImage?: ContentfulImageAsset | null;
   datePublished?: string | null;
+  seoTitle?: string | null;
+  seoDescription?: string | null;
 }
 
 export interface BlogPost extends BlogPostSummary {
   content: RichTextDocument | null;
   author?: BlogPostAuthor | null;
-  seoDescription?: string | null;
   affiliate?: boolean;
   affiliateCtaText?: string | null;
   affiliateCtaUrl?: string | null;
@@ -89,6 +90,18 @@ export interface BlogPost extends BlogPostSummary {
   sponsoredLabel?: string | null;
   disclosureNeeded?: boolean;
   disableAutoLinks?: boolean;
+  recipe?: BlogPostRecipe | null;
+}
+
+export interface BlogPostRecipe {
+  name?: string | null;
+  description?: string | null;
+  yield?: string | null;
+  prepTime?: string | number | null;
+  cookTime?: string | number | null;
+  totalTime?: string | number | null;
+  ingredients?: string[] | null;
+  instructions?: string[] | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize blog post SEO metadata, open graph, and JSON-LD generation with recipe support
- extend Contentful models and lint tooling to surface seoTitle, seoDescription, and recipe data for schema
- enforce canonical domain traffic via middleware redirect

## Testing
- npm run lint
- npm run build
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d735d46308832fb5f2af55c1fb466c