### PR TITLE
Docs: add editorial content strategy and templates

### DIFF
--- a/docs/editorial/README.md
+++ b/docs/editorial/README.md
@@ -1,0 +1,21 @@
+# Editorial Operations Kit
+
+This kit centralizes the repeatable process for planning, outlining, drafting, and optimizing Grounded Living content across recipes, herbal remedies, and lifestyle practices.
+
+## Contents
+- [`content-strategy.md`](./content-strategy.md) — cornerstone pillars, clusters, keyword approach, structural standards.
+- [`keyword-brief-template.md`](./keyword-brief-template.md) — assignable worksheet for SEO research.
+- [`outline-template.md`](./outline-template.md) — structure for writer outlines and approval.
+- [`draft-checklist.md`](./draft-checklist.md) — ensures drafts meet editorial quality before submission.
+- [`optimization-checklist.md`](./optimization-checklist.md) — QA tool to satisfy acceptance tests and SEO requirements.
+- [`image-spec-sheet.md`](./image-spec-sheet.md) — photography and graphic guidelines.
+
+## Usage Workflow
+1. **Strategize:** Choose topic from `content-strategy.md`, generate keyword brief.
+2. **Assign:** Share brief and outline template with writer or subject-matter expert.
+3. **Draft:** Writer completes checklist while drafting, embedding citations and media requirements.
+4. **Optimize:** Editor runs optimization checklist, ensures schema and internal links are complete.
+5. **Publish & Review:** Upload assets following image spec, monitor analytics against performance benchmarks.
+
+Maintaining strict adherence to these artifacts supports consistency, E-E-A-T, and the goal of compounding organic traffic and subscriber growth.
+

--- a/docs/editorial/content-strategy.md
+++ b/docs/editorial/content-strategy.md
@@ -1,0 +1,84 @@
+# Grounded Living Editorial Strategy
+
+## Mission & Tone
+- **Mission:** Deliver helpful, evidence-backed recipes, remedies, and lifestyle guidance that inspires readers to nurture resilient wellness habits.
+- **Voice:** Warm, grounded, science-aware, and optimistic. Always cite reputable primary sources (peer-reviewed journals, registered dietitians, licensed herbalists) when discussing health benefits or safety.
+- **Authenticity:** Feature personal testing notes, sensory cues, and honest disclaimers about when to seek professional support.
+
+## Cornerstone Categories & Topical Clusters
+The blog is organized around three cornerstone pillars. Each pillar contains clusters that ladder into cornerstone guides and support a network of interlinked posts.
+
+### 1. Nourish & Restore (Recipes)
+| Cluster | Search Intent | Sample Long-Tail Targets |
+| --- | --- | --- |
+| Immune Support Kitchen | Recipes that aid seasonal resilience and cold/flu recovery. | elderberry ginger syrup without sugar, vitamin c smoothie for sore throat, turmeric bone broth for colds, zinc-rich soup recipe, antioxidant-packed citrus salad winter, fire cider gummies for immunity |
+| Hormone Harmony Meals | Meals and snacks aligned with cycle support and endocrine balance. | seed cycling energy bites recipe, magnesium-rich chocolate smoothie, dairy-free chai latte for pms, gluten-free breakfast for hormonal acne, high-protein luteal phase salad, herbal iced tea for hot flashes |
+| Gut-Friendly Comforts | Comfort foods adapted for digestion and microbiome health. | low-fodmap miso soup recipe, fermented carrot kraut instructions, prebiotic oatmeal bake, soothing marshmallow root latte, bone broth ramen for leaky gut, ginger coconut rice pudding |
+
+### 2. Herbal Remedies & Rituals (Remedies)
+| Cluster | Search Intent | Sample Long-Tail Targets |
+| --- | --- | --- |
+| Stress & Sleep Soothers | DIY herbal blends and evening rituals for rest. | lemon balm tincture for anxiety, passionflower sleep tea recipe, magnesium bath soak diy, chamomile lavender pillow spray, adaptogenic moon milk without dairy, grounding bedtime breathing ritual |
+| Everyday Immunity Toolkit | Preventative herbal preparations and acute-response care. | astragalus immune tonic recipe, thyme honey cough syrup, elderflower steam for sinus relief, garlic oxymel instructions, echinacea tincture dosage adults, immune support herbal first aid kit |
+| Skin & Beauty From Within | Topical and ingestible remedies for holistic skincare. | calendula infused oil for eczema, rosehip facial serum diy, nettle tea for hair growth, anti-inflammatory smoothie for acne, clay mask with probiotics recipe, collagen-support herbal gummies |
+
+### 3. Mindful Living Practices (Lifestyle)
+| Cluster | Search Intent | Sample Long-Tail Targets |
+| --- | --- | --- |
+| Seasonal Rhythm Guides | Align routines, foods, and rituals with the seasons. | spring ayurvedic routine checklist, summer hydration habits for runners, autumn grounding practices for vata, winter self-care hygge ritual, solstice cleansing meditation script, seasonal pantry staples list |
+| Home Sanctuary & Ritual | Create calming, low-tox home environments. | natural linen spray with essential oils, smoke-free cleansing rituals, diy beeswax candles for beginners, herbal simmer pot combinations, mindful cleaning checklist printable, toxin-free laundry routine |
+| Conscious Family Wellness | Holistic habits for households and caregivers. | herbal popsicles for teething, kids immune-boosting smoothie, mindful morning routine for families, calming bedtime yoga for toddlers, prenatal nesting checklist natural, postnatal herb bath recipe |
+
+## Keyword Strategy Framework
+1. **Primary keyword per post** sourced from long-tail targets above (KD ≤35, SV 50–1,000).
+2. **Secondary synonyms & semantic helpers** pulled via People Also Ask, Google Autocomplete, and RankIQ. Include "natural," "holistic," "evidence-based," variations when relevant.
+3. **FAQ targeting:** Capture question keywords (e.g., "Is fire cider safe during pregnancy?") answered with citations.
+4. **Internal link map:** Each post links to:
+   - Cornerstone guide overview page.
+   - 2 sibling posts in the same cluster.
+   - 1 post from another pillar for cross-pollination (e.g., recipe linking to lifestyle bedtime ritual).
+5. **Conversion focus:** Every post aligns with a tailored lead magnet (immune meal plan, herbal starters guide, seasonal reset workbook).
+
+## Post Structure Standards
+1. **SEO Metadata:** Provide `seo_title`, `seo_description`, and `excerpt` fields (≤ 160 characters) with the primary keyword near the front.
+2. **Opening Hook:** 2–3 sentences introducing the benefit and personal angle; include the primary keyword.
+3. **Featured Media:** One landscape hero image (1200×630) with descriptive alt text referencing the recipe/remedy; one vertical image (1000×1500) optimized for Pinterest.
+4. **Ingredients / Materials:** Bullet or table format with measurements + sourcing notes; link to shop page or affiliate only when ethical.
+5. **Step-by-Step Instructions:** Numbered steps with sensory cues, timing, and doneness markers; include printable card component (see Recipe Card spec) with schema.
+6. **Nutrition & Safety Notes:** Highlight macros, allergen swaps, contraindications; cite registered dietitian or clinical herbalist sources.
+7. **Evidence-Anchored Insights:** For each health claim, cite at least one reputable source and briefly summarize findings in natural language.
+8. **FAQs:** Minimum of 3 questions using long-tail queries; answer concisely with citations.
+9. **Internal Links & CTAs:** Add in-line links and "You may also love" related posts block; close with newsletter CTA tailored to topic.
+10. **Schema Requirements:** Recipes use `Recipe` schema; remedies and lifestyle posts use `HowTo` or `Article` schema with `citation` and `author` fields populated.
+
+## Related Posts Component Guidelines
+- Dynamically surface 3 posts within the same cluster + 1 cross-pillar suggestion.
+- Include recipe/remedy cards with prep time, difficulty, and quick benefit statement.
+- Encourage exploration: "Keep your rhythm steady with…" style copy.
+
+## Newsletter CTA Library
+| Context | CTA Copy | Lead Magnet |
+| --- | --- | --- |
+| Immune Support Recipes | "Get my 7-day immunity meal plan with make-ahead shopping list." | PDF meal plan |
+| Stress & Sleep Rituals | "Download the Calm Evenings Rituals guide with printable tea timers." | Rituals guide |
+| Gut-Friendly Comforts | "Join the Nourish Digest email series—3 gut-loving recipes each week." | Email series |
+| Seasonal Rhythm Guides | "Receive the Seasonal Reset workbook delivered every equinox." | Workbook |
+| Conscious Family Wellness | "Grab the Family Wellness Toolkit with kid-friendly herbal swaps." | Toolkit |
+
+## Performance Benchmarks
+- **Optimization Checklist Compliance:** 100% adherence tracked via editorial QA (see checklists).
+- **Engagement Goals:** Average time-on-page ≥ 2:30, pages/session ≥ 1.6 within 60 days.
+- **Conversion Tracking:** Monitor newsletter opt-ins per CTA in analytics dashboard.
+
+## Workflow Overview
+1. **Ideation:** Select keywords from cluster list, validate competitiveness, and assign to writers with keyword brief template.
+2. **Outline:** Writer submits outline using standardized outline template for editor approval.
+3. **Drafting:** Writer drafts in markdown using draft checklist; includes citations, images, schema components.
+4. **Optimization & QA:** Apply optimization checklist, ensure internal links and metadata complete, verify schema via Rich Results Test.
+5. **Publish & Monitor:** Schedule posts, update internal linking matrix monthly, evaluate analytics to iterate on CTAs and content refresh opportunities.
+
+## Continuous Improvement
+- Quarterly keyword refresh using Search Console data and emerging seasonal trends.
+- Content decay audits every 6 months to refresh stats, sources, and CTAs.
+- Encourage reader feedback via comments/polls to identify new cluster opportunities.
+

--- a/docs/editorial/draft-checklist.md
+++ b/docs/editorial/draft-checklist.md
@@ -1,0 +1,28 @@
+# Draft Checklist
+
+## Before Writing
+- [ ] Review keyword brief and outline approval notes.
+- [ ] Confirm latest research/citations (<3 years when possible) and safety data.
+- [ ] Gather firsthand testing notes and photography plan.
+
+## During Drafting
+- [ ] Primary keyword in title, intro paragraph, one H2, and naturally through body.
+- [ ] Include descriptive hook with reader benefit and empathy.
+- [ ] Provide ingredient/equipment lists with measurements and sourcing tips.
+- [ ] Write numbered steps with actionable detail and timing; add recipe/remedy card component.
+- [ ] Integrate personal insights or testing notes for authenticity.
+- [ ] Add evidence callouts with citations linked inline using markdown footnotes or reference style.
+- [ ] Insert minimum of 3 FAQ entries with keyword-aligned questions.
+- [ ] Plan internal links (cornerstone, 2 cluster, 1 cross-pillar) in contextually relevant spots.
+- [ ] Draft tailored newsletter CTA copy tied to lead magnet.
+
+## Pre-Submission QA
+- [ ] Verify seo_title (≤60 char), seo_description (≤160 char), and excerpt (≤150 words) are completed.
+- [ ] Ensure alt text for all images is descriptive, keyword-adjacent, and under 125 characters.
+- [ ] Double-check schema block (Recipe/HowTo/Article) includes prep time, yield, author, keywords, citations.
+- [ ] Confirm nutrition/safety notes include disclaimers and cite credentialed sources.
+- [ ] Run Hemingway/Grammarly readability check (grade ≤8 while preserving nuance).
+- [ ] Validate links (internal/external) are functional and open in correct context.
+- [ ] Attach imagery (hero, process, Pinterest) with filenames reflecting keyword.
+- [ ] Submit draft in Markdown via CMS/repo with frontmatter complete.
+

--- a/docs/editorial/image-spec-sheet.md
+++ b/docs/editorial/image-spec-sheet.md
@@ -1,0 +1,38 @@
+# Image Specification Sheet
+
+## Core Requirements
+- **File Formats:** .webp preferred for hero/inline; .jpg acceptable for Pinterest vertical; .png for graphics with transparency.
+- **Color Profile:** sRGB.
+- **Resolution:** Minimum 300 dpi for printables; 72 dpi for web images.
+- **Naming Convention:** `keyword-descriptor-dimension.webp` (e.g., `elderberry-syrup-hero-1200x630.webp`).
+- **Alt Text:** 80–125 characters, describing action/ingredients + keyword.
+
+## Hero Image
+- **Dimensions:** 1200×630 px.
+- **Composition:** Natural light, minimal props, focus on finished dish/remedy in vessel.
+- **File Size Goal:** ≤300 KB (use TinyPNG/Squoosh).
+- **Usage:** Open Graph, featured image, schema `image` field.
+
+## Process / Step Images
+- **Quantity:** Minimum 3 for recipes/remedies showing key steps.
+- **Dimensions:** 1000×750 px (4:3) or 1200×800 px.
+- **Notes:** Include hands-in-motion shots, highlight texture/consistency.
+- **Captions:** Brief instruction reinforcement (≤15 words).
+
+## Vertical / Pinterest Graphic
+- **Dimensions:** 1000×1500 px.
+- **Design:** Branded color palette, readable overlay text (≤12 words), include logo/URL.
+- **File Size Goal:** ≤400 KB.
+- **CTA Tagline:** "Pin now, brew later" or relevant quick hook.
+
+## Infographics / Printables
+- **Dimensions:** 1080×1920 px for stories; 8.5×11 in for printable PDF exports.
+- **Accessibility:** Provide text alternative or summary in post.
+
+## Photography Workflow
+1. Shoot in RAW; edit in Lightroom with consistent preset.
+2. Export web versions via Photoshop or Squoosh using compression.
+3. Generate alt text referencing key ingredients and sensory cues.
+4. Upload to CMS with correct filenames and complete captions/credits.
+5. Archive RAW + edited files in cloud folder organized by post slug.
+

--- a/docs/editorial/keyword-brief-template.md
+++ b/docs/editorial/keyword-brief-template.md
@@ -1,0 +1,22 @@
+# Keyword Brief Template
+
+- **Post Title (Working):**
+- **Primary Keyword:**
+- **Search Intent:** Informational / Transactional / Navigational / Hybrid
+- **Monthly Search Volume:**
+- **Keyword Difficulty / Priority Score:**
+- **Supporting Terms:** (List 5–8 semantic variations)
+- **People Also Ask / FAQ Targets:** (3–5 questions)
+- **Cluster & Pillar:**
+- **Target Persona & Stage:** (e.g., postpartum parent seeking gentle remedies)
+- **Lead Magnet CTA:**
+- **Featured Expert or Source Opportunities:**
+- **Top SERP Notes:**
+  - URL + differentiator for top 3 competitors
+  - Content gaps to outperform
+- **Internal Link Prompts:** Cornerstone, 2 sibling posts, 1 cross-pillar
+- **Visual Assets Needed:** Hero, step/process shots, vertical graphic, downloadable checklist
+- **Citation Requirements:** Minimum reputable sources to include
+- **Draft Deadline & Publish Window:**
+- **Success Metric:** (e.g., time-on-page goal, conversions)
+

--- a/docs/editorial/optimization-checklist.md
+++ b/docs/editorial/optimization-checklist.md
@@ -1,0 +1,42 @@
+# Optimization Checklist
+
+## Metadata & Frontmatter
+- [ ] `seo_title` contains primary keyword near beginning and ≤60 characters.
+- [ ] `seo_description` (≤160 characters) summarizes benefit + CTA.
+- [ ] `excerpt` (≤150 words) is compelling and aligns with intro.
+- [ ] Slug uses lowercase hyphenation and includes keyword.
+
+## Structure & Content
+- [ ] H1 mirrors or complements seo_title with keyword.
+- [ ] H2/H3 cascade follows outline and includes semantic keywords.
+- [ ] Intro references reader pain point + promise within first 100 words.
+- [ ] Includes ingredient/material lists, equipment, and step-by-step instructions.
+- [ ] Nutrition/safety section cites at least two reputable sources.
+- [ ] FAQ block answers ≥3 long-tail questions with citations.
+
+## Links & CTAs
+- [ ] Internal link to cornerstone guide, 2 sibling posts, 1 cross-pillar post.
+- [ ] External links only to high-authority, reputable sources (gov, edu, peer-reviewed, credentialed experts).
+- [ ] Newsletter CTA present, tailored to topic, with functioning signup link.
+- [ ] Related posts component populated with correct slugs and metadata.
+
+## Media & Schema
+- [ ] Hero image (1200×630) compressed <300 KB with descriptive alt text.
+- [ ] Vertical Pinterest image (1000×1500) included with branded overlay text.
+- [ ] Process or step images include captions and alt text.
+- [ ] Recipe card or HowTo block includes prep time, cook time, yield, ingredients, instructions, notes.
+- [ ] JSON-LD/structured data validated via Rich Results Test.
+
+## Quality & Accessibility
+- [ ] Flesch-Kincaid grade ≤8 without losing nuance.
+- [ ] Sentences ≤25 words on average; use bullets/tables for scannability.
+- [ ] All measurements provided in both imperial and metric when relevant.
+- [ ] Disclaimers present for medical/health advice, linking to policies.
+- [ ] Grammar and spell-check run; no passive voice clusters.
+- [ ] Page previewed on mobile and desktop breakpoints.
+
+## Post-Publish
+- [ ] Submit URL to search console for indexing.
+- [ ] Add post to internal linking tracker/spreadsheet.
+- [ ] Schedule performance review (30- and 60-day checkpoints).
+

--- a/docs/editorial/outline-template.md
+++ b/docs/editorial/outline-template.md
@@ -1,0 +1,50 @@
+# Outline Template
+
+- **Post Title:**
+- **Primary Keyword:**
+- **Working SEO Title (≤60 characters):**
+- **Hook / Intro (50–80 words):**
+- **Key Promise:** What transformation or takeaway the reader gets.
+
+## H2 Structure
+1. H2 Title (include keyword variation)
+   - Key talking points (bullets)
+   - Internal link to ___
+   - Source(s) to cite
+2. H2 Title
+   - ...
+
+> Repeat for each planned H2/H3. Keep sections scannable (≤200 words before subhead).
+
+## Recipe / Remedy Card Components (if applicable)
+- Yield / Serving size:
+- Prep + Cook time:
+- Equipment needed:
+- Ingredients list (bullets):
+- Step sequence (numbered):
+- Notes / substitutions:
+
+## Evidence & Safety Notes
+- Claim 1 + supporting study/source
+- Claim 2 + supporting study/source
+- Contraindications / disclaimers to mention
+
+## Visual Plan
+- Hero image concept + props
+- Process shots (list each step to capture)
+- Vertical/Pinterest graphic concept
+
+## CTA & Lead Magnet Placement
+- CTA copy idea:
+- Placement (after section __ / in card / sticky banner):
+
+## FAQ Draft Questions
+1.
+2.
+3.
+(Optional 4–5)
+
+## Additional Assets
+- Downloadables, printables, or embedded audio/video
+- Cross-promotion opportunities (podcast episode, product)
+


### PR DESCRIPTION
## Summary
- define cornerstone editorial categories with detailed keyword clusters and performance goals
- document repeatable workflow for briefs, outlines, drafting, optimization, and publishing
- add reusable templates and checklists covering SEO metadata, schema, imagery, and CTA requirements

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d73d3683f0832f9c8d27f4db1401d2