### PR TITLE
Feat: add inline newsletter CTAs and affiliate foundations

### DIFF
--- a/app/(site)/blog/[slug]/page.tsx
+++ b/app/(site)/blog/[slug]/page.tsx
@@ -3,7 +3,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { AffiliateDisclosure } from "@/components/blog/AffiliateDisclosure";
+import { InlineNewsletterPortal } from "@/components/blog/InlineNewsletterPortal";
+import { PostEngagementPoll } from "@/components/blog/PostEngagementPoll";
 import { PostCard } from "@components/blog/PostCard";
+import { SocialShareButtons } from "@/components/blog/SocialShareButtons";
 import { Breadcrumbs } from "@/components/nav/Breadcrumbs";
 import { NewsletterSignup } from "@components/marketing/NewsletterSignup";
 import { JsonLd } from "@/components/seo/JsonLd";
@@ -161,6 +164,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       </header>
       <div className="post-body">
         <div className="prose rt-container" dangerouslySetInnerHTML={{ __html: html }} />
+        <InlineNewsletterPortal slug={post.slug} />
+        <SocialShareButtons url={canonicalUrl} title={post.title} />
+        <PostEngagementPoll slug={post.slug} />
         <section className="post-author">
           <h3>About the author</h3>
           <div className="post-author-card">

--- a/app/(site)/thank-you/page.tsx
+++ b/app/(site)/thank-you/page.tsx
@@ -14,6 +14,18 @@ const LEAD_MAGNETS: Record<string, { title: string; description: string; file: s
     description: "A gentle framework to help you unwind, reset, and close the day with intention.",
     file: "/lead-magnets/evening-ritual-checklist.pdf",
   },
+  "herbal-remedies-cold-season": {
+    title: "5 Herbal Remedies for Cold Season",
+    description:
+      "A concise reference for easing cold season discomfort with trusted botanicals, safety notes, and brewing guidance.",
+    file: "/lead-magnets/herbal-remedies-cold-season.pdf",
+  },
+  "whole-food-breakfast-blueprint": {
+    title: "7-Day Whole-Food Breakfast Blueprint",
+    description:
+      "Seven quick-prep, dietitian-reviewed breakfasts with macros, swap ideas, and prep notes for calmer mornings.",
+    file: "/lead-magnets/whole-food-breakfast-blueprint.pdf",
+  },
 };
 
 export const metadata: Metadata = {

--- a/app/globals.css
+++ b/app/globals.css
@@ -310,6 +310,75 @@ video {
   gap: var(--space-xs);
 }
 
+.site-header__social {
+  display: none;
+}
+
+.social-links {
+  list-style: none;
+  display: flex;
+  gap: 0.65rem;
+  padding: 0;
+  margin: 0;
+}
+
+.social-links__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: var(--radius-pill);
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: rgba(26, 46, 36, 0.88);
+  background: rgba(250, 247, 242, 0.75);
+  border: 1px solid rgba(91, 127, 107, 0.22);
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.social-links__link:hover,
+.social-links__link:focus-visible {
+  color: var(--color-moss-strong);
+  border-color: rgba(91, 127, 107, 0.45);
+  background: rgba(91, 127, 107, 0.16);
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.social-links__icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.social-links--compact .social-links__link {
+  padding: 0.3rem;
+  width: 2.15rem;
+  height: 2.15rem;
+  justify-content: center;
+}
+
+.social-links--compact .social-links__label {
+  display: none;
+}
+
+.social-links--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.social-links--stacked .social-links__link {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+@media (min-width: 768px) {
+  .site-header__social {
+    display: flex;
+    margin-right: 0.35rem;
+  }
+}
+
 .search-trigger {
   display: inline-flex;
   align-items: center;
@@ -480,6 +549,10 @@ details[open] .site-nav__panel {
 .site-footer__contact a {
   color: var(--color-moss);
   font-weight: 600;
+}
+
+.site-footer__social {
+  margin-top: 1.25rem;
 }
 
 .site-footer__meta {
@@ -675,6 +748,60 @@ details[open] .site-nav__panel {
 .newsletter-form__status:empty {
   display: none;
   min-height: 0;
+}
+
+.post-inline-newsletter {
+  margin: clamp(2.5rem, 6vw, 4.5rem) 0;
+}
+
+.inline-newsletter {
+  border-radius: var(--radius-2xl);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  background: linear-gradient(135deg, rgba(91, 127, 107, 0.12), rgba(250, 247, 242, 0.92));
+  border: 1px solid rgba(91, 127, 107, 0.18);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.inline-newsletter__eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(19, 34, 30, 0.55);
+}
+
+.inline-newsletter__title {
+  font-family: var(--font-display, "Fraunces", serif);
+  font-size: clamp(1.4rem, 1.1rem + 1vw, 1.75rem);
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+}
+
+.inline-newsletter__body {
+  color: rgba(19, 34, 30, 0.75);
+  font-size: var(--font-size-base);
+}
+
+.inline-newsletter__bullets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+  font-size: var(--font-size-sm);
+  color: rgba(19, 34, 30, 0.7);
+}
+
+.inline-newsletter__bullets li::before {
+  content: "•";
+  margin-right: 0.4rem;
+  color: var(--color-moss);
+}
+
+.inline-newsletter .newsletter-form__inline-fields {
+  flex-wrap: wrap;
 }
 
 .newsletter-form--inline {
@@ -1568,6 +1695,128 @@ details[open] .site-nav__panel {
 .post-body {
   display: grid;
   gap: clamp(2rem, 5vw, 3rem);
+}
+
+.post-share {
+  border-radius: 1.75rem;
+  border: 1px solid rgba(91, 127, 107, 0.18);
+  background: rgba(250, 247, 242, 0.9);
+  padding: clamp(1.25rem, 4vw, 1.75rem);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.post-share__heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 650;
+  color: rgba(19, 34, 30, 0.75);
+}
+
+.post-share__icon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.post-share__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.post-share__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(91, 127, 107, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+  color: rgba(19, 34, 30, 0.75);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.post-share__button:hover,
+.post-share__button:focus-visible {
+  color: var(--color-moss-strong);
+  border-color: rgba(91, 127, 107, 0.45);
+  background: rgba(91, 127, 107, 0.16);
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.post-poll {
+  border-radius: 1.75rem;
+  border: 1px solid rgba(91, 127, 107, 0.18);
+  background: rgba(239, 236, 229, 0.65);
+  padding: clamp(1.25rem, 4vw, 1.85rem);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.post-poll__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.post-poll__icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  color: var(--color-moss);
+}
+
+.post-poll__header h3 {
+  margin: 0;
+  font-family: var(--font-display, "Fraunces", serif);
+  font-size: 1.25rem;
+}
+
+.post-poll__header p {
+  margin: 0.35rem 0 0 0;
+  font-size: var(--font-size-sm);
+  color: rgba(19, 34, 30, 0.7);
+}
+
+.post-poll__options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.post-poll__option {
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(91, 127, 107, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 0.6rem 1rem;
+  text-align: left;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: rgba(19, 34, 30, 0.75);
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.post-poll__option:hover,
+.post-poll__option:focus-visible {
+  color: var(--color-moss-strong);
+  border-color: rgba(91, 127, 107, 0.45);
+  background: rgba(91, 127, 107, 0.16);
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.post-poll__option--selected {
+  background: rgba(91, 127, 107, 0.18);
+  border-color: rgba(91, 127, 107, 0.6);
+  color: var(--color-moss-strong);
 }
 
 .post-author {

--- a/components/blog/InlineNewsletterPortal.tsx
+++ b/components/blog/InlineNewsletterPortal.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { NewsletterForm } from "@/components/ui/NewsletterForm";
+
+interface InlineNewsletterPortalProps {
+  slug: string;
+}
+
+interface InlineVariant {
+  id: string;
+  eyebrow: string;
+  title: string;
+  body: string;
+  bullets: string[];
+  submitLabel: string;
+  hint: string;
+  successRedirect: string;
+  tag: string;
+}
+
+const INLINE_VARIANTS: InlineVariant[] = [
+  {
+    id: "herbal-remedies",
+    eyebrow: "Free download",
+    title: "5 Herbal Remedies for Cold Season",
+    body: "Build a gentle apothecary at home with clinically backed herbs, dosing tips, and safety notes.",
+    bullets: [
+      "Immune-supporting teas & tonics",
+      "When to reach for elderberry vs. echinacea",
+      "Contraindications to watch for",
+    ],
+    submitLabel: "Send me the PDF",
+    hint: "We’ll email the guide and a weekly ritual note. Unsubscribe anytime.",
+    successRedirect: "/thank-you?lg=herbal-remedies-cold-season",
+    tag: "lead-magnet:herbal-remedies",
+  },
+  {
+    id: "whole-food-breakfasts",
+    eyebrow: "7-day reset",
+    title: "Whole-Food Breakfast Blueprint",
+    body: "Seven make-ahead breakfasts that balance blood sugar, reduce morning stress, and taste like comfort.",
+    bullets: [
+      "Dietitian-reviewed macro breakdowns",
+      "Batch-prep notes for busy weeks",
+      "Swap suggestions for seasonal produce",
+    ],
+    submitLabel: "Email the breakfast plan",
+    hint: "No spam—just nourishing recipes and gentle accountability.",
+    successRedirect: "/thank-you?lg=whole-food-breakfast-blueprint",
+    tag: "lead-magnet:whole-food-breakfasts",
+  },
+];
+
+function hashSlug(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function InlineNewsletterPortal({ slug }: InlineNewsletterPortalProps) {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const variant = useMemo(() => {
+    if (INLINE_VARIANTS.length === 0) {
+      throw new Error("Inline newsletter variants must be configured");
+    }
+    const index = hashSlug(slug) % INLINE_VARIANTS.length;
+    return INLINE_VARIANTS[index];
+  }, [slug]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    const root = document.querySelector<HTMLElement>(".post-body");
+    if (!root) {
+      return undefined;
+    }
+
+    const element = document.createElement("div");
+    element.className = "post-inline-newsletter not-prose";
+    element.dataset.variant = variant.id;
+
+    const headings = root.querySelectorAll<HTMLElement>(".rt-heading-2");
+    const target = headings[1] ?? headings[0];
+
+    if (target) {
+      target.insertAdjacentElement("afterend", element);
+    } else {
+      root.appendChild(element);
+    }
+
+    setContainer(element);
+
+    return () => {
+      element.remove();
+      setContainer(null);
+    };
+  }, [variant]);
+
+  if (!container) {
+    return null;
+  }
+
+  return createPortal(<InlineNewsletter variant={variant} />, container);
+}
+
+function InlineNewsletter({ variant }: { variant: InlineVariant }) {
+  return (
+    <aside className="inline-newsletter" aria-label="Join the Grounded Living newsletter">
+      <p className="inline-newsletter__eyebrow">{variant.eyebrow}</p>
+      <h2 className="inline-newsletter__title">{variant.title}</h2>
+      <p className="inline-newsletter__body">{variant.body}</p>
+      <ul className="inline-newsletter__bullets">
+        {variant.bullets.map((bullet) => (
+          <li key={bullet}>{bullet}</li>
+        ))}
+      </ul>
+      <NewsletterForm
+        variant="inline"
+        hideLabel
+        submitLabel={variant.submitLabel}
+        hint={variant.hint}
+        source="post-inline"
+        successRedirect={variant.successRedirect}
+        tag={variant.tag}
+      />
+    </aside>
+  );
+}

--- a/components/blog/PostEngagementPoll.tsx
+++ b/components/blog/PostEngagementPoll.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { MessageCircle } from "lucide-react";
+
+interface PostEngagementPollProps {
+  slug: string;
+}
+
+const POLL_KEY_PREFIX = "gl:post-poll:";
+
+const POLL_OPTIONS: { value: string; label: string }[] = [
+  { value: "try", label: "I’m trying this ritual this week" },
+  { value: "adapt", label: "I’ll adapt it to my routine" },
+  { value: "share", label: "Sending to a friend who needs it" },
+];
+
+export function PostEngagementPoll({ slug }: PostEngagementPollProps) {
+  const storageKey = `${POLL_KEY_PREFIX}${slug}`;
+  const [selection, setSelection] = useState<string | null>(null);
+  const [message, setMessage] = useState("Help us tailor future guides—how will you use this piece?");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (stored) {
+        setSelection(stored);
+        setMessage("Thanks for letting us know! Your response shapes future rituals.");
+      }
+    } catch (error) {
+      console.warn("Unable to read poll selection", error);
+    }
+  }, [storageKey]);
+
+  const handleSelect = (value: string) => {
+    setSelection(value);
+    setMessage("Thanks for letting us know! Your response shapes future rituals.");
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, value);
+    } catch (error) {
+      console.warn("Unable to persist poll selection", error);
+    }
+  };
+
+  return (
+    <section className="post-poll" aria-labelledby="post-poll-title">
+      <div className="post-poll__header">
+        <MessageCircle aria-hidden className="post-poll__icon" />
+        <div>
+          <h3 id="post-poll-title">Join the conversation</h3>
+          <p aria-live="polite">{message}</p>
+        </div>
+      </div>
+      <div className="post-poll__options">
+        {POLL_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className={`post-poll__option${selection === option.value ? " post-poll__option--selected" : ""}`}
+            onClick={() => handleSelect(option.value)}
+            aria-pressed={selection === option.value}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/blog/SocialShareButtons.tsx
+++ b/components/blog/SocialShareButtons.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+import { Link2, Share2, Send } from "lucide-react";
+
+interface SocialShareButtonsProps {
+  url: string;
+  title: string;
+}
+
+export function SocialShareButtons({ url, title }: SocialShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const shareData = { title, url };
+
+  const handleWebShare = async () => {
+    if (typeof navigator === "undefined") {
+      return;
+    }
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+      } catch (error) {
+        console.warn("Share cancelled", error);
+      }
+      return;
+    }
+
+    await copyLink();
+  };
+
+  const copyLink = async () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      if (typeof window !== "undefined") {
+        window.setTimeout(() => setCopied(false), 1500);
+      }
+    } catch (error) {
+      console.warn("Unable to copy link", error);
+    }
+  };
+
+  const openWindow = (shareUrl: string) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const width = 600;
+    const height = 540;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+    window.open(
+      shareUrl,
+      "share-window",
+      `width=${width},height=${height},left=${left},top=${top},noopener,noreferrer`,
+    );
+  };
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  const shareTo = (network: "pinterest" | "facebook" | "x") => {
+    switch (network) {
+      case "pinterest":
+        openWindow(`https://www.pinterest.com/pin/create/button/?url=${encodedUrl}&description=${encodedTitle}`);
+        break;
+      case "facebook":
+        openWindow(`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`);
+        break;
+      case "x":
+        openWindow(`https://x.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="post-share" aria-label="Share this article">
+      <div className="post-share__heading">
+        <Share2 aria-hidden className="post-share__icon" />
+        <span>Share this ritual</span>
+      </div>
+      <div className="post-share__actions">
+        <button
+          type="button"
+          className="post-share__button"
+          onClick={handleWebShare}
+          aria-label="Share via your favorite app"
+        >
+          <Send aria-hidden />
+          <span>Quick share</span>
+        </button>
+        <button type="button" className="post-share__button" onClick={() => shareTo("pinterest")} aria-label="Share on Pinterest">
+          <span aria-hidden>P</span>
+          <span>Pinterest</span>
+        </button>
+        <button type="button" className="post-share__button" onClick={() => shareTo("facebook")} aria-label="Share on Facebook">
+          <span aria-hidden>f</span>
+          <span>Facebook</span>
+        </button>
+        <button type="button" className="post-share__button" onClick={() => shareTo("x")} aria-label="Share on X">
+          <span aria-hidden>X</span>
+          <span>Post</span>
+        </button>
+        <button type="button" className="post-share__button" onClick={copyLink} aria-label="Copy article link">
+          <Link2 aria-hidden />
+          <span>{copied ? "Link copied" : "Copy link"}</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Container } from "@/components/ui/Container";
 import { NewsletterForm } from "@/components/ui/NewsletterForm";
+import { SocialLinks } from "@/components/site/SocialLinks";
 import { getCategories } from "@/lib/contentful";
 
 const pageLinks = [
@@ -79,6 +80,7 @@ export async function Footer() {
                 </li>
               </ul>
             </nav>
+            <SocialLinks variant="stacked" className="site-footer__social" />
           </div>
         </div>
         <p className="site-footer__meta">&copy; {year} Grounded Living. All rights reserved.</p>

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SearchBox, useSearchController } from "@/components/search/SearchBox";
 import { SearchResults } from "@/components/search/SearchResults";
 import { Container } from "@/components/ui/Container";
+import { SocialLinks } from "@/components/site/SocialLinks";
 
 const navigation = [
   { href: "/", label: "Home" },
@@ -128,6 +129,7 @@ export function Header() {
           ))}
         </nav>
         <div className="site-header__actions">
+          <SocialLinks variant="compact" className="site-header__social" />
           <button
             type="button"
             className="search-trigger"

--- a/components/site/NewsletterRibbon.tsx
+++ b/components/site/NewsletterRibbon.tsx
@@ -6,6 +6,41 @@ import { NewsletterForm } from "@/components/ui/NewsletterForm";
 
 const STORAGE_KEY = "gl:newsletter-ribbon:v1";
 const DISMISS_VALUE = "dismissed";
+const VARIANT_STORAGE_KEY = "gl:newsletter-ribbon:variant";
+
+interface RibbonVariant {
+  id: string;
+  eyebrow: string;
+  title: string;
+  body: string;
+  submitLabel: string;
+  hint: string;
+  successRedirect: string;
+  tag: string;
+}
+
+const RIBBON_VARIANTS: RibbonVariant[] = [
+  {
+    id: "slow-rituals",
+    eyebrow: "Weekly rituals",
+    title: "Ground your week with slow, evidence-backed rituals.",
+    body: "Receive seasonal recipes, holistic wellness essays, and gentle prompts to reset your routine.",
+    submitLabel: "Join the list",
+    hint: "One thoughtful email each week—unsubscribe anytime.",
+    successRedirect: "/thank-you?lg=herbal-remedies-cold-season",
+    tag: "lead-magnet:herbal-remedies",
+  },
+  {
+    id: "seasonal-kitchen",
+    eyebrow: "Kitchen inspiration",
+    title: "Plan nourishing breakfasts without the morning scramble.",
+    body: "Get the 7-day whole-food breakfast blueprint plus weekly seasonal menu notes.",
+    submitLabel: "Send the plan",
+    hint: "Quick recipes, no spam. Opt out anytime.",
+    successRedirect: "/thank-you?lg=whole-food-breakfast-blueprint",
+    tag: "lead-magnet:whole-food-breakfasts",
+  },
+];
 
 function getStoredDismissal(): boolean {
   if (typeof window === "undefined") {
@@ -35,8 +70,38 @@ function persistDismissal() {
 type RibbonStyle = CSSProperties & { "--ribbon-offset"?: string };
 
 export function NewsletterRibbon() {
+  const defaultVariant = RIBBON_VARIANTS[0];
+  if (!defaultVariant) {
+    return null;
+  }
+
   const [isOpen, setIsOpen] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [variant, setVariant] = useState<RibbonVariant>(defaultVariant);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const storedVariant = window.localStorage.getItem(VARIANT_STORAGE_KEY);
+      const fallbackVariant = storedVariant
+        ? RIBBON_VARIANTS.find((item) => item.id === storedVariant)
+        : undefined;
+      if (fallbackVariant) {
+        setVariant(fallbackVariant);
+        return;
+      }
+
+      const index = Math.floor(Math.random() * RIBBON_VARIANTS.length);
+      const selected = RIBBON_VARIANTS[index] ?? RIBBON_VARIANTS[0];
+      setVariant(selected);
+      window.localStorage.setItem(VARIANT_STORAGE_KEY, selected.id);
+    } catch (error) {
+      console.warn("Unable to resolve newsletter ribbon variant", error);
+    }
+  }, []);
 
   useEffect(() => {
     if (getStoredDismissal()) {
@@ -142,22 +207,23 @@ export function NewsletterRibbon() {
       role="complementary"
       aria-label="Join the Grounded Living newsletter"
       style={style}
+      data-variant={variant.id}
     >
       <div className="newsletter-ribbon__content">
         <div className="newsletter-ribbon__copy">
-          <p className="newsletter-ribbon__eyebrow">Weekly rituals</p>
-          <h2 className="newsletter-ribbon__title">Ground your week with slow, evidence-backed rituals.</h2>
-          <p className="newsletter-ribbon__body">
-            Receive seasonal recipes, holistic wellness essays, and gentle prompts to reset your routine.
-          </p>
+          <p className="newsletter-ribbon__eyebrow">{variant.eyebrow}</p>
+          <h2 className="newsletter-ribbon__title">{variant.title}</h2>
+          <p className="newsletter-ribbon__body">{variant.body}</p>
         </div>
         <div className="newsletter-ribbon__form">
           <NewsletterForm
             variant="inline"
             hideLabel
             source="sticky-ribbon"
-            submitLabel="Join the list"
-            hint="One thoughtful email each week—unsubscribe anytime."
+            submitLabel={variant.submitLabel}
+            hint={variant.hint}
+            successRedirect={variant.successRedirect}
+            tag={variant.tag}
           />
         </div>
         <button

--- a/components/site/SocialLinks.tsx
+++ b/components/site/SocialLinks.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+
+import { Instagram, Youtube, Mail } from "lucide-react";
+
+import { cn } from "@/lib/utils/cn";
+
+interface SocialLinksProps {
+  className?: string;
+  variant?: "compact" | "stacked";
+  showLabels?: boolean;
+}
+
+interface SocialLinkItem {
+  key: string;
+  label: string;
+  href: string;
+  icon: typeof Instagram;
+}
+
+const DEFAULT_LINKS: SocialLinkItem[] = [
+  {
+    key: "instagram",
+    label: "Instagram",
+    href: "https://www.instagram.com/groundedlivingjournal",
+    icon: Instagram,
+  },
+  {
+    key: "youtube",
+    label: "YouTube",
+    href: "https://www.youtube.com/@groundedliving",
+    icon: Youtube,
+  },
+  {
+    key: "email",
+    label: "Email",
+    href: `mailto:${process.env.NEXT_PUBLIC_CONTACT_EMAIL ?? "hello@groundedliving.org"}`,
+    icon: Mail,
+  },
+];
+
+function resolveSocialLinks(): SocialLinkItem[] {
+  return DEFAULT_LINKS.map((item) => {
+    const envKey = `NEXT_PUBLIC_SOCIAL_${item.key.toUpperCase()}` as keyof NodeJS.ProcessEnv;
+    const envValue = process.env[envKey];
+    if (typeof envValue === "string" && envValue.trim().length > 0) {
+      return { ...item, href: envValue.trim() };
+    }
+    return item;
+  });
+}
+
+export function SocialLinks({ className, variant = "compact", showLabels = variant === "stacked" }: SocialLinksProps) {
+  const links = useMemo(() => resolveSocialLinks(), []);
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className={cn("social-links", `social-links--${variant}`, className)}>
+      {links.map(({ key, label, href, icon: Icon }) => (
+        <li key={key} className="social-links__item">
+          <Link
+            href={href}
+            className="social-links__link"
+            aria-label={showLabels ? undefined : label}
+            target={href.startsWith("mailto:") ? undefined : "_blank"}
+            rel={href.startsWith("mailto:") ? undefined : "noreferrer noopener"}
+          >
+            <Icon aria-hidden className="social-links__icon" />
+            {showLabels ? <span className="social-links__label">{label}</span> : null}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/content/posts/breakfast-tools-i-actually-use.md
+++ b/content/posts/breakfast-tools-i-actually-use.md
@@ -1,0 +1,24 @@
+---
+title: "Breakfast Tools I Actually Use"
+date: "2024-09-26"
+category: "Kitchen"
+tags:
+  - breakfast
+  - gear
+  - affiliate
+description: "The exact tools that make whole-food breakfasts doable, aligned with our new seven-day blueprint."
+---
+
+Whole-food breakfasts feel effortless when your tools stay simple and multi-purpose. These are the pieces I reach for every week while following the Whole-Food Breakfast Blueprint.
+
+## Batch-friendly cookware
+
+The [Our Place Always Pan](https://example.com/our-place-pan?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) sautés veggies, bakes frittatas, and steams oats without swapping pans mid-recipe. Pair it with a [sheet pan cooling rack](https://example.com/cooling-rack?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) for crisp granola clusters.
+
+## Blend-and-go essentials
+
+For smoothies and chia puddings, the [Beast Blender](https://example.com/beast-blender?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) creates silky textures without overheating produce. Pre-portion servings using [Stojo collapsible cups](https://example.com/stojo?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) so mornings stay clutter-free.
+
+## Storage that keeps produce fresh
+
+Use [Ello glass containers](https://example.com/ello-containers?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) to hold prepped veggies and protein bites. Slip in a [Greensaver crisper insert](https://example.com/greensaver?utm_source=blog&utm_medium=affiliate&utm_campaign=breakfast-tools) to extend the life of tender herbs and greens.

--- a/content/posts/calm-lighting-guide.md
+++ b/content/posts/calm-lighting-guide.md
@@ -1,0 +1,24 @@
+---
+title: "Calm Lighting Guide"
+date: "2024-10-10"
+category: "Home"
+tags:
+  - lighting
+  - sleep hygiene
+  - affiliate
+description: "Create circadian-friendly lighting with our favourite lamps, bulbs, and rituals."
+---
+
+Lighting dictates our nervous system cues. Swap harsh bulbs for calming alternatives to support melatonin production and a grounded evening routine.
+
+## Swap to circadian-supportive bulbs
+
+Install [GE Cync Reveal bulbs](https://example.com/reveal-bulb?utm_source=blog&utm_medium=affiliate&utm_campaign=calm-lighting) in bedside lamps for warm evening light, then schedule a cooler spectrum for mornings. Their app-based dimming makes transitions effortless.
+
+## Layer lamps with soft diffusion
+
+Pair a [Himalayan salt lamp](https://example.com/salt-lamp?utm_source=blog&utm_medium=affiliate&utm_campaign=calm-lighting) with your meditation corner to disperse amber light, and keep an [IKEA linen lantern](https://example.com/linen-lantern?utm_source=blog&utm_medium=affiliate&utm_campaign=calm-lighting) in the living room for a gentle glow while reading.
+
+## Ritualize digital sunsets
+
+Use [Flux screen filters](https://example.com/flux?utm_source=blog&utm_medium=affiliate&utm_campaign=calm-lighting) on laptops and schedule the [Hatch Restore 2](https://example.com/hatch-restore?utm_source=blog&utm_medium=affiliate&utm_campaign=calm-lighting) to begin a sound bath one hour before bed. Combine this with our Evening Ritual Checklist to reinforce consistent cues.

--- a/content/posts/herbalists-winter-cabinet.md
+++ b/content/posts/herbalists-winter-cabinet.md
@@ -1,0 +1,24 @@
+---
+title: "Herbalist’s Winter Cabinet"
+date: "2024-09-19"
+category: "Apothecary"
+tags:
+  - herbs
+  - immunity
+  - affiliate
+description: "Stock an herbal cabinet for colder months with vetted ingredients and brewing tools."
+---
+
+Winter resilience starts long before the first frost. Building a humble herbal cabinet ensures you can brew comfort on demand without scrambling for supplies.
+
+## Core botanicals to pre-order
+
+Begin with foundational allies like [Mountain Rose Herbs elderberries](https://example.com/elderberries?utm_source=blog&utm_medium=affiliate&utm_campaign=herbal-cabinet) for syrups and [organic thyme](https://example.com/thyme?utm_source=blog&utm_medium=affiliate&utm_campaign=herbal-cabinet) for steam inhalations. Pair them with our **5 Herbal Remedies for Cold Season** PDF for dosing reminders and contraindications.
+
+## Brewing equipment that simplifies rituals
+
+A heat-safe [French press](https://example.com/french-press?utm_source=blog&utm_medium=affiliate&utm_campaign=herbal-cabinet) doubles as an infusion vessel and strainer. For on-the-go immunity, keep [amber glass dropper bottles](https://example.com/dropper-bottles?utm_source=blog&utm_medium=affiliate&utm_campaign=herbal-cabinet) ready to portion tinctures for the week ahead.
+
+## Storage and labeling best practices
+
+Use airtight [weck jars](https://example.com/weck-jars?utm_source=blog&utm_medium=affiliate&utm_campaign=herbal-cabinet) to preserve potency. Label each with purchase date, sourcing notes, and key benefits so your future self knows exactly what to reach for.

--- a/content/posts/supplements-with-real-science.md
+++ b/content/posts/supplements-with-real-science.md
@@ -1,0 +1,24 @@
+---
+title: "Supplements with Real Science"
+date: "2024-10-03"
+category: "Wellness"
+tags:
+  - supplements
+  - evidence-based
+  - affiliate
+description: "Evidence-backed supplements we recommend through practitioner-grade partners."
+---
+
+Supplements should do more than fill a shelf—they must address documented deficiencies and complement lifestyle interventions. These picks are practitioner-approved and available through our Fullscript dispensary.
+
+## Foundational nutrients
+
+If lab work shows a gap, consider [Fullscript magnesium glycinate](https://example.com/magnesium?utm_source=blog&utm_medium=affiliate&utm_campaign=supplements-science) for nervous system regulation and [methylated B-complex](https://example.com/b-complex?utm_source=blog&utm_medium=affiliate&utm_campaign=supplements-science) to support energy metabolism. Share results with your healthcare provider before starting any protocol.
+
+## Targeted adaptogens
+
+On high-stress weeks, [Apothekary Chill The F Out](https://example.com/chill-out?utm_source=blog&utm_medium=affiliate&utm_campaign=supplements-science) blends ashwagandha and reishi in clinically relevant doses. We also rely on [Four Sigmatic focus blend](https://example.com/focus-blend?utm_source=blog&utm_medium=affiliate&utm_campaign=supplements-science) to pair with morning journaling.
+
+## Sleep support
+
+For gentle sleep hygiene, [beam dream powder](https://example.com/beam-dream?utm_source=blog&utm_medium=affiliate&utm_campaign=supplements-science) combines L-theanine and nano CBD. Use it alongside blue-light-blocking rituals and our Evening Ritual Checklist for best results.

--- a/content/posts/toolkit-for-slow-living.md
+++ b/content/posts/toolkit-for-slow-living.md
@@ -1,0 +1,24 @@
+---
+title: "Toolkit for Slow Living"
+date: "2024-09-12"
+category: "Guides"
+tags:
+  - affiliate
+  - slow living
+  - wellness
+description: "Our essential tools, pantry staples, and rituals that keep slow living practical, supported by trusted affiliate partners."
+---
+
+Cultivating a calm, grounded home doesn’t require a full redesign—just a few intentional tools that support your rituals. This guide curates our most-used items, each vetted for sustainability, quality, and the way it reinforces our slow-living philosophy.
+
+## Kitchen anchors for mindful meals
+
+The kitchen sets the tone for every ritual. We reach for the [Our Place Always Pan](https://example.com/our-place-pan?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) when batch-prepping breakfast bakes; its modular design replaces multiple pots without sacrificing heat control. For pantry restocks, a [Thrive Market membership](https://example.com/thrive-market?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) keeps organic staples accessible and affordable.
+
+## Herbal comforts on standby
+
+Cold evenings call for a stocked apothecary. Keep [Mountain Rose Herbs elderberries](https://example.com/elderberries?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) ready for syrup making and a calming [Fullscript magnesium glycinate](https://example.com/magnesium?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) when you need nervous-system support. Pair these with our new herbal remedies PDF to move from inspiration to action.
+
+## Recovery tools for nervous system care
+
+Slow living is also about rest. A breathable [linen eye mask](https://example.com/linen-mask?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) reduces blue light, while the [Hatch Restore 2](https://example.com/hatch-restore?utm_source=blog&utm_medium=affiliate&utm_campaign=toolkit-slow-living) eases transitions between evening and sleep. Use them alongside our evening checklist ritual for a full-body reset.

--- a/content/posts/weekly-meal-prep-flow.md
+++ b/content/posts/weekly-meal-prep-flow.md
@@ -1,0 +1,24 @@
+---
+title: "Weekly Meal Prep Flow"
+date: "2024-10-17"
+category: "Routine"
+tags:
+  - meal prep
+  - planning
+  - affiliate
+description: "Our step-by-step weekend flow for stress-free meals, featuring pantry bundles we actually buy."
+---
+
+A gentle meal prep routine keeps weekday decisions light. This flow takes under two hours and leans on pantry partners we trust.
+
+## Gather staples in one delivery
+
+Order a [Thrive Market pantry bundle](https://example.com/thrive-bundle?utm_source=blog&utm_medium=affiliate&utm_campaign=meal-prep-flow) with grains, legumes, and nut milks so you start stocked. Keep [OXO pop containers](https://example.com/oxo-pop?utm_source=blog&utm_medium=affiliate&utm_campaign=meal-prep-flow) labeled for quick scoops and inventory checks.
+
+## Batch cook in stages
+
+Use the [Our Place Perfect Pot](https://example.com/perfect-pot?utm_source=blog&utm_medium=affiliate&utm_campaign=meal-prep-flow) for soups while roasting veggies on [USA Pan sheet pans](https://example.com/usa-pan?utm_source=blog&utm_medium=affiliate&utm_campaign=meal-prep-flow). Rotate items into cooling racks so textures stay crisp.
+
+## Portion and store mindfully
+
+Divide meals into [W&P porter bowls](https://example.com/porter-bowls?utm_source=blog&utm_medium=affiliate&utm_campaign=meal-prep-flow) and log leftovers in a simple note or Notion template. Add a reminder to thaw breakfast bakes the night before so mornings stay easy.

--- a/docs/marketing/affiliate-programs.md
+++ b/docs/marketing/affiliate-programs.md
@@ -1,0 +1,38 @@
+# Affiliate Program Blueprint
+
+Grounded Living integrates affiliate partners sparingly and transparently. The following programs are approved for phase-one monetisation and align with our ingredient and sourcing standards.
+
+## Active Programs
+
+| Partner | Focus | Notes |
+| --- | --- | --- |
+| **Amazon Associates** | Books, small kitchen equipment, sleep tech | Use only for products we have tested; prefer single ASIN per recommendation to minimise reader overwhelm. |
+| **Thrive Market** | Pantry staples, adaptogens, sustainable household goods | Link to curated collections; mention membership pricing and free-trial terms. |
+| **Our Place** | Modular cookware for batch prepping | Highlight non-toxic materials and multi-use efficiency; perfect for breakfast blueprint emails. |
+| **Mountain Rose Herbs** | Organic herbs and apothecary tools | Ideal for the herbal remedies magnet; include sourcing transparency snippet. |
+| **Fullscript** | Professional-grade supplements (invite-only) | Leverage practitioner recommendations; remind readers to consult healthcare providers. |
+
+## Disclosure Pattern
+
+1. **Above-the-fold banner** on any affiliate-heavy post using `<AffiliateDisclosure />`.
+2. **Inline context** before each recommendation (e.g., "We earn a small commission if you purchase through this link. It keeps Grounded Living ad-light.").
+3. **Footer reminder** within long-form buyer’s guides referencing the full [Disclosure](/disclosure) page.
+
+## Tracking & Measurement
+
+- Tag outbound links with `?utm_source=blog&utm_medium=affiliate&utm_campaign=<post-slug>`.
+- Monitor CTR in Plausible and partner dashboards; target ≥ 2% per module.
+- Log revenue milestones in the marketing dashboard; first goal is $100 within 90 days.
+
+## Content Roadmap
+
+Create or refresh the following posts with affiliate context:
+
+1. **Toolkit for Slow Living** – hero roundup linking to all partner categories.
+2. **Herbalist’s Winter Cabinet** – align with the new cold-season PDF.
+3. **Breakfast Tools I Actually Use** – integrate Our Place, blender, storage containers.
+4. **Supplements with Real Science** – focus on practitioner-grade options.
+5. **Calm Lighting Guide** – include circadian-friendly bulbs and salt lamps.
+6. **Weekly Meal Prep Flow** – highlight Thrive Market pantry bundles.
+
+Each post should open with reader pain points, outline evaluation criteria, and close with the inline newsletter CTA so visitors join the list after engaging with commerce content.

--- a/docs/marketing/welcome-series.md
+++ b/docs/marketing/welcome-series.md
@@ -1,0 +1,51 @@
+# Grounded Living Welcome Series
+
+A five-email nurture journey that delivers value first, establishes trust, and gently introduces affiliate partners once subscribers are primed.
+
+## Email 1 – Subject: "Welcome to your grounding ritual" (Day 0)
+- **Intent:** Deliver the promised lead magnet immediately and set expectations.
+- **Key elements:**
+  - Hero link to the subscriber’s selected resource (auto-personalized via the `lg` query param).
+  - Brief origin story about Grounded Living’s mission and cadence (weekly Sunday send + seasonal check-ins).
+  - Soft CTA to add our address to their contacts plus a teaser of upcoming topics.
+- **PS:** Invite readers to reply with their biggest seasonal challenge for qualitative insights.
+
+## Email 2 – Subject: "Your 3-step evening wind-down" (Day 3)
+- **Intent:** Reinforce value with a practical mini ritual sourced from top-performing posts.
+- **Key elements:**
+  - 3 actionable steps with estimated time commitments.
+  - Embedded testimonial pull-quote from the community.
+  - CTA to explore the “Evening Ritual Checklist” PDF for deeper guidance (non-sales).
+- **PS:** Link to a mindfulness audio on the blog to encourage site revisit.
+
+## Email 3 – Subject: "Seasonal kitchen staples you'll love" (Day 7)
+- **Intent:** Introduce food-first support that connects to the Whole-Food Breakfast Blueprint magnet.
+- **Key elements:**
+  - Curated grocery list with swaps for various dietary needs.
+  - Mini poll (linking to `/thank-you?lg=whole-food-breakfast-blueprint`) to choose their breakfast persona.
+  - CTA to read the “Pantry essentials for calm mornings” blog post.
+- **PS:** Invite readers to forward the email to a friend who needs calmer mornings.
+
+## Email 4 – Subject: "Tools we actually rely on" (Day 12)
+- **Intent:** Warm affiliate introduction via authentic recommendations.
+- **Key elements:**
+  - Story-led intro about solving a community pain point.
+  - Feature three affiliate partners (e.g., Thrive Market, Our Place pan, high-quality adaptogen brand) with evidence-backed benefits.
+  - Explicit disclosure line above the module and reiteration of our review criteria.
+- **CTA:** Button leading to the "Toolkit for Slow Living" roundup post.
+
+## Email 5 – Subject: "Choose your next ritual" (Day 20)
+- **Intent:** Segmentation + retention.
+- **Key elements:**
+  - Interactive prompt linking to the on-site poll (saves preference in localStorage).
+  - Buttons for three pathways: Sleep rituals, Seasonal cooking, Nervous system care.
+  - Encourage subscribers to update their preferences (link to profile center once available).
+- **CTA:** Invite readers to follow us on Instagram or YouTube for behind-the-scenes rituals.
+
+---
+
+### Implementation Notes
+- Configure in ESP with behavior-based delays (pause Email 2 if the subscriber hasn’t opened Email 1 within 72 hours).
+- Tag subscribers based on magnet (`lead-magnet:herbal-remedies`, `lead-magnet:whole-food-breakfasts`, etc.) to personalize dynamic blocks.
+- Track `welcome_series_open` and `welcome_series_click` events via the analytics layer to monitor the 45% / 5% targets.
+- After Email 5, transition subscribers to the weekly digest with the chosen topic emphasis.

--- a/public/lead-magnets/herbal-remedies-cold-season.pdf
+++ b/public/lead-magnets/herbal-remedies-cold-season.pdf
@@ -1,0 +1,53 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 500 >>
+stream
+BT
+/F1 24 Tf
+72 740 Td
+(5 Herbal Remedies for Cold Season) Tj
+/F1 14 Tf
+0 -32 Td
+(Soothe sniffles with gentle, evidence-backed botanicals.) Tj
+0 -22 Td
+() Tj
+0 -22 Td
+(1. Elderberry syrup basics and safe dosing cues) Tj
+0 -22 Td
+(2. Thyme steam for stubborn congestion relief) Tj
+0 -22 Td
+(3. Fire cider add-ins for extra warmth and circulation) Tj
+0 -22 Td
+(4. When to pause herbs and call your practitioner) Tj
+0 -22 Td
+() Tj
+0 -22 Td
+(Plus: weekly inbox rituals to stay grounded all season.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+862
+%%EOF

--- a/public/lead-magnets/whole-food-breakfast-blueprint.pdf
+++ b/public/lead-magnets/whole-food-breakfast-blueprint.pdf
@@ -1,0 +1,53 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 498 >>
+stream
+BT
+/F1 24 Tf
+72 740 Td
+(7-Day Whole-Food Breakfast Blueprint) Tj
+/F1 14 Tf
+0 -32 Td
+(Batch-friendly breakfasts to steady your mornings.) Tj
+0 -22 Td
+() Tj
+0 -22 Td
+(1. Overnight chia pudding with citrus-maca boost) Tj
+0 -22 Td
+(2. Miso greens omelette cups ready in 15 minutes) Tj
+0 -22 Td
+(3. Spiced quinoa porridge with roasted pears) Tj
+0 -22 Td
+(4. Savory oat bake featuring seasonal vegetables) Tj
+0 -22 Td
+() Tj
+0 -22 Td
+(Includes macro notes, swaps, and planner prompts in your inbox.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+860
+%%EOF

--- a/stubs/lucide-react.tsx
+++ b/stubs/lucide-react.tsx
@@ -140,6 +140,59 @@ export const X = createIcon(
   </>
 );
 
+export const Instagram = createIcon(
+  <>
+    <rect x="3" y="3" width="18" height="18" rx="5" />
+    <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+    <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+  </>
+);
+
+export const Youtube = createIcon(
+  <>
+    <path d="M2.5 17.5v-11a2 2 0 0 1 2-2h15a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2h-15a2 2 0 0 1-2-2z" />
+    <path d="m10 15 5-3-5-3z" />
+  </>
+);
+
+export const Mail = createIcon(
+  <>
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <polyline points="3 7 12 13 21 7" />
+  </>
+);
+
+export const Share2 = createIcon(
+  <>
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </>
+);
+
+export const Link2 = createIcon(
+  <>
+    <path d="M9 17H7a5 5 0 0 1 0-10h2" />
+    <path d="M15 7h2a5 5 0 0 1 0 10h-2" />
+    <line x1="8" y1="12" x2="16" y2="12" />
+  </>
+);
+
+export const Send = createIcon(
+  <>
+    <path d="m22 2-7 20-4-9-9-4Z" />
+    <path d="M22 2 11 13" />
+  </>
+);
+
+export const MessageCircle = createIcon(
+  <>
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5Z" />
+  </>
+);
+
 export default {
   LayoutDashboard,
   FileText,
@@ -155,4 +208,11 @@ export default {
   Moon,
   SunMedium,
   X,
+  Instagram,
+  Youtube,
+  Mail,
+  Share2,
+  Link2,
+  Send,
+  MessageCircle,
 };


### PR DESCRIPTION
## Summary
- inject inline newsletter variants, social sharing, and an engagement poll on blog posts while surfacing social links in the header/footer and testing a/b ribbon copy
- publish two new lead magnets and expose them through the thank-you flow plus inline signup variants
- document the welcome series and affiliate blueprint while seeding six commerce-ready markdown posts

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73f6dd7bc832fa8ea84ccb08ae858