### PR TITLE
Add infographic module support and printable recipe cards

### DIFF
--- a/app/(site)/[slug]/page.tsx
+++ b/app/(site)/[slug]/page.tsx
@@ -53,7 +53,17 @@ export async function generateMetadata({ params }: GenericPageProps): Promise<Me
         alt: page.ogImage.description ?? page.ogImage.title ?? metaTitle,
       }
     : null;
-  const ogImages = ogImage ? [ogImage] : [{ url: ogImageForTitle(metaTitle) }];
+  const ogImages = ogImage
+    ? [ogImage]
+    : [
+        {
+          url: ogImageForTitle(metaTitle, {
+            subtitle: description,
+            eyebrow: page.slug === "contact" ? "Connect" : "Guide",
+            variant: "editorial",
+          }),
+        },
+      ];
 
   return {
     title: metaTitle,

--- a/app/(site)/journal/page.tsx
+++ b/app/(site)/journal/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { ArticleShell } from "@/components/blog/ArticleShell";
+import { InfographicCard } from "@/components/blog/InfographicCard";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { getAllBlogPosts } from "@/lib/contentful";
 import { canonicalFor } from "@/lib/seo/meta";
@@ -21,7 +22,7 @@ export const revalidate = 300;
 
 export async function generateMetadata(): Promise<Metadata> {
   const canonicalUrl = canonicalFor("/journal").toString();
-  const ogImageUrl = ogImageForTitle(PAGE_TITLE);
+  const ogImageUrl = ogImageForTitle(PAGE_TITLE, { subtitle: PAGE_DESCRIPTION, eyebrow: "Journal", variant: "editorial" });
 
   return {
     title: META_TITLE,
@@ -123,6 +124,20 @@ export default async function JournalPage() {
             Fresh stories are brewing. Check back soon for the latest rituals and reflections.
           </p>
         )}
+      </div>
+      <div className="mt-16 not-prose">
+        <InfographicCard
+          eyebrow="Editorial tools"
+          title="How to stage a nervous system reset"
+          summary="A four-part ritual to help your readers pause, breathe, nourish, and restore—perfect for sharing on social."
+          items={[
+            { title: "Ground", description: "Start with a slow, diaphragmatic breathing practice to cue safety." },
+            { title: "Nourish", description: "Sip a magnesium-forward tonic and swap blue light for amber glow." },
+            { title: "Restore", description: "Journal three supportive thoughts, then stretch before bed." },
+          ]}
+          footnote="Download the printable infographic to embed in your next wellness guide."
+          theme="moss"
+        />
       </div>
     </ArticleShell>
   );

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -7,6 +7,9 @@ import { Gtag } from "@/components/analytics/Gtag";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { Footer } from "@/components/site/Footer";
 import { Header } from "@/components/site/Header";
+import { LiveAnnouncer } from "@/components/site/LiveAnnouncer";
+import { PageTransition } from "@/components/site/PageTransition";
+import { ThemeProvider } from "@/components/site/ThemeProvider";
 import { NewsletterRibbon } from "@/components/site/NewsletterRibbon";
 import { bodyFontLocal, displayFontLocal, fallbackFontFamilies } from "@/lib/fonts";
 import { siteUrl } from "@/lib/site";
@@ -77,22 +80,27 @@ interface SiteLayoutProps {
 export default function SiteLayout({ children }: SiteLayoutProps) {
   return (
     <ConsentProvider>
-      <div className={`${fontClasses} ${fontVariables}`}>
-        <style>{`:root{--font-display:${displayFontFamily};--font-body:${bodyFontFamily};}`}</style>
-        <a href="#content" className="skip-link">
-          Skip to content
-        </a>
-        <Header />
-        <main id="content" className="site-main" role="main">
-          {children}
-        </main>
-        <NewsletterRibbon />
-        <Footer />
-        <ConsentBanner />
-        <Gtag />
-        <SpeedInsights />
-        <JsonLd item={websiteJsonLd} id="website-schema" />
-      </div>
+      <ThemeProvider>
+        <LiveAnnouncer />
+        <div className={`${fontClasses} ${fontVariables}`}>
+          <style>{`:root{--font-display:${displayFontFamily};--font-body:${bodyFontFamily};}`}</style>
+          <a href="#content" className="skip-link">
+            Skip to content
+          </a>
+          <Header />
+          <PageTransition>
+            <main id="content" className="site-main" role="main">
+              {children}
+            </main>
+          </PageTransition>
+          <NewsletterRibbon />
+          <Footer />
+          <ConsentBanner />
+          <Gtag />
+          <SpeedInsights />
+          <JsonLd item={websiteJsonLd} id="website-schema" />
+        </div>
+      </ThemeProvider>
     </ConsentProvider>
   );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -5,6 +5,7 @@ import { HeroCarousel } from "@components/blog/HeroCarousel";
 import { PostCard } from "@components/blog/PostCard";
 import { NewsletterSignup } from "@components/marketing/NewsletterSignup";
 import { buttonClassNames } from "@/components/ui/Button";
+import { Reveal } from "@/components/ui/Reveal";
 import { getAllBlogPosts, getCategories, getPages } from "@lib/contentful";
 import type { BlogPostSummary, ContentfulPage, RichTextNode } from "@project-types/contentful";
 
@@ -18,7 +19,7 @@ export default async function HomePage() {
 
   return (
     <div className="stack-xl">
-      <section className="home-hero">
+      <Reveal as="section" className="home-hero" delay={60}>
         <div className="home-hero-copy">
           <span className="hero-eyebrow">Grounded rituals for intentional living</span>
           <h1>Your sanctuary for soulful wellness</h1>
@@ -36,9 +37,9 @@ export default async function HomePage() {
           </div>
         </div>
         <HeroCarousel posts={featured} />
-      </section>
+      </Reveal>
 
-      <section className="home-section">
+      <Reveal as="section" className="home-section" delay={120}>
         <div className="section-header">
           <div>
             <span className="section-eyebrow">Discover</span>
@@ -49,9 +50,9 @@ export default async function HomePage() {
           </Link>
         </div>
         <CategoryChips categories={categories} />
-      </section>
+      </Reveal>
 
-      <section className="home-section">
+      <Reveal as="section" className="home-section" delay={160}>
         <div className="section-header">
           <div>
             <span className="section-eyebrow">Fresh from the journal</span>
@@ -66,12 +67,14 @@ export default async function HomePage() {
             <PostCard key={post.id} post={post} />
           ))}
         </div>
-      </section>
+      </Reveal>
 
-      <NewsletterSignup />
+      <Reveal as="div" className="home-newsletter" delay={200}>
+        <NewsletterSignup />
+      </Reveal>
 
       {aboutPage ? (
-        <section className="home-section about-highlight">
+        <Reveal as="section" className="home-section about-highlight" delay={220}>
           <div className="section-header">
             <div>
               <span className="section-eyebrow">About</span>
@@ -84,7 +87,7 @@ export default async function HomePage() {
           <div className="about-panel">
             <RichTextPreview content={aboutPage.content?.content ?? []} />
           </div>
-        </section>
+        </Reveal>
       ) : null}
     </div>
   );

--- a/app/(site)/recipes/page.tsx
+++ b/app/(site)/recipes/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
 
 import { RecipeLayout } from "@/components/recipes/RecipeLayout";
+import { RecipeCard } from "@/components/recipes/RecipeCard";
+import type { RecipeCardProps } from "@/components/recipes/RecipeCard";
 import { Container } from "@/components/ui/Container";
 import { Section } from "@/components/ui/Section";
+import { Reveal } from "@/components/ui/Reveal";
 import { buildMetaTitle } from "@/lib/seo/title";
 import { truncateAtBoundary } from "@/lib/seo/text";
 
@@ -72,20 +75,87 @@ const SAMPLE_RECIPE = {
   ),
 } as const;
 
+const FEATURED_RECIPES: ReadonlyArray<RecipeCardProps> = [
+  {
+    title: "Sunrise Adaptogen Latte",
+    description: "Cordyceps, turmeric, and coconut butter to ignite a calm, sustained morning energy without spikes.",
+    href: "/recipes/sunrise-adaptogen-latte",
+    image: {
+      src: "/images/recipes/moon-milk.svg",
+      alt: "Stoneware mug with adaptogen latte surrounded by herbs",
+    },
+    meta: {
+      prep: "5 mins",
+      cook: "7 mins",
+      yield: "1 mug",
+    },
+  },
+  {
+    title: "Glow Greens Superfood Broth",
+    description: "Mineral-dense broth concentrate with moringa, kelp, and shiitake to sip or fold into grains.",
+    href: "/recipes/glow-greens-broth",
+    image: {
+      src: "/images/recipes/moon-milk.svg",
+      alt: "Jar of vibrant green broth with spoon and herbs",
+    },
+    meta: {
+      prep: "10 mins",
+      cook: "45 mins",
+      yield: "4 cups",
+    },
+  },
+  {
+    title: "Evening Magnesium Cocoa",
+    description: "Magnesium glycinate, raw cacao, and tart cherry for deeper sleep support in a cozy, modern tonic.",
+    href: "/recipes/evening-magnesium-cocoa",
+    image: {
+      src: "/images/recipes/moon-milk.svg",
+      alt: "Cup of evening cocoa with cinnamon and candle",
+    },
+    meta: {
+      prep: "5 mins",
+      cook: "8 mins",
+      yield: "2 mugs",
+    },
+  },
+];
+
 export default function RecipesLandingPage() {
   return (
     <Section className="bg-surface-canvas">
       <Container className="space-y-16">
-        <header className="max-w-3xl space-y-6">
+        <Reveal as="header" className="max-w-3xl space-y-6">
           <p className="text-sm font-semibold uppercase tracking-[0.32em] text-moss-600">Recipes</p>
           <h1 className="font-display text-4xl">Rooted nourishment for calm energy</h1>
           <p className="text-lg text-ink-soft md:w-3/4">
             Our kitchen lab works through every ritual recipe with clinical herbalists and dietitians. Each template keeps prep easy,
             ingredients functional, and presentation print-friendly.
           </p>
-        </header>
+        </Reveal>
 
-        <RecipeLayout {...SAMPLE_RECIPE} />
+        <Reveal>
+          <RecipeLayout {...SAMPLE_RECIPE} />
+        </Reveal>
+
+        <Reveal as="section" className="space-y-10">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.32em] text-moss-600">Recipe library</p>
+              <h2 className="font-display text-3xl">Print-ready favourites</h2>
+            </div>
+            <p className="max-w-xl text-sm text-ink-soft">
+              Each recipe card is typeset for half-sheet printing and quick sharing. Save them to your tablet cookbook or pin to
+              the fridge for weekly planning.
+            </p>
+          </div>
+          <ul className="recipe-card-grid" role="list">
+            {FEATURED_RECIPES.map((recipe) => (
+              <li key={recipe.title} className="recipe-card-grid__item">
+                <RecipeCard {...recipe} />
+              </li>
+            ))}
+          </ul>
+        </Reveal>
       </Container>
     </Section>
   );

--- a/app/(site)/shop/page.tsx
+++ b/app/(site)/shop/page.tsx
@@ -5,6 +5,7 @@ import { ProductCard } from "@/components/shop/ProductCard";
 import { TrackEvent } from "@/components/analytics/TrackEvent";
 import { Container } from "@/components/ui/Container";
 import { Section } from "@/components/ui/Section";
+import { Reveal } from "@/components/ui/Reveal";
 import { getAllProducts } from "@/lib/shop/products";
 import { canonicalFor } from "@/lib/seo/meta";
 import { buildMetaTitle } from "@/lib/seo/title";
@@ -28,13 +29,29 @@ export const metadata: Metadata = {
     url: canonicalFor("/shop").toString(),
     title: META_TITLE,
     description: META_DESCRIPTION,
-    images: [{ url: ogImageForTitle(PAGE_TITLE) }],
+    images: [
+      {
+        url: ogImageForTitle(PAGE_TITLE, {
+          variant: "commerce",
+          subtitle: PAGE_DESCRIPTION,
+          eyebrow: "Shop",
+          tag: "Future Commerce",
+        }),
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: META_TITLE,
     description: META_DESCRIPTION,
-    images: [ogImageForTitle(PAGE_TITLE)],
+    images: [
+      ogImageForTitle(PAGE_TITLE, {
+        variant: "commerce",
+        subtitle: PAGE_DESCRIPTION,
+        eyebrow: "Shop",
+        tag: "Future Commerce",
+      }),
+    ],
   },
 };
 
@@ -60,18 +77,21 @@ export default function ShopPage() {
       <JsonLd item={itemList} id="shop-item-list" />
       <Section className="pb-16 pt-12 md:pt-16">
         <Container className="space-y-12">
-          <header className="space-y-5 text-center md:text-left">
+          <Reveal as="header" className="space-y-5 text-center md:text-left">
             <p className="text-sm font-semibold uppercase tracking-[0.35em] text-moss-600">Grounded Living Shop</p>
             <h1 className="text-4xl font-semibold text-ink md:text-5xl">{PAGE_TITLE}</h1>
             <p className="mx-auto max-w-2xl text-lg text-ink/80 md:mx-0">{PAGE_DESCRIPTION}</p>
             <p className="mx-auto max-w-2xl text-sm text-ink/60 md:mx-0">{DISCLAIMER_TEXT}</p>
-          </header>
+          </Reveal>
           <ul className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
             {products.map((product) => (
               <ProductCard key={product.slug} product={product} />
             ))}
           </ul>
-          <div className="rounded-3xl border border-ink/10 bg-white/70 p-6 text-sm text-ink/70">
+          <Reveal
+            as="div"
+            className="rounded-3xl border border-[color:var(--card-border-default)] bg-[var(--card-bg-default)] p-6 text-sm text-ink/70 shadow-[var(--card-shadow-default)]"
+          >
             <h2 className="text-base font-semibold text-ink">Transparency quick facts</h2>
             <ul className="mt-3 space-y-2">
               <li>
@@ -84,7 +104,7 @@ export default function ShopPage() {
                 <strong className="text-ink">Questions:</strong> Email <a className="underline" href="mailto:hello@groundedliving.org">hello@groundedliving.org</a> for sourcing or contraindication clarifications.
               </li>
             </ul>
-          </div>
+          </Reveal>
         </Container>
       </Section>
       <TrackEvent event="shop_index_viewed" params={{ product_count: products.length }} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -95,6 +95,21 @@
   --surface-card: rgba(248, 245, 242, 0.9);
   --surface-subtle: rgba(255, 255, 255, 0.8);
   --surface-overlay: rgba(19, 34, 30, 0.36);
+  --card-bg-default: rgba(248, 245, 242, 0.9);
+  --card-border-default: rgba(19, 34, 30, 0.08);
+  --card-shadow-default: 0 28px 84px -48px rgba(19, 34, 30, 0.45);
+  --card-bg-moss: rgba(241, 247, 244, 0.88);
+  --card-border-moss: rgba(91, 127, 107, 0.22);
+  --card-shadow-moss: 0 24px 72px -48px rgba(91, 127, 107, 0.45);
+  --card-bg-linen: rgba(250, 247, 242, 0.92);
+  --card-border-linen: rgba(38, 33, 28, 0.18);
+  --card-shadow-linen: 0 20px 68px -48px rgba(38, 33, 28, 0.35);
+  --button-secondary-bg: rgba(255, 255, 255, 0.82);
+  --button-secondary-border: rgba(91, 127, 107, 0.24);
+  --button-secondary-color: rgba(19, 34, 30, 0.82);
+  --button-ghost-hover: rgba(19, 34, 30, 0.08);
+  --button-secondary-hover-bg: rgba(241, 247, 244, 0.92);
+  --button-secondary-border-hover: rgba(91, 127, 107, 0.42);
   --space-4xs: 0.125rem;
   --space-3xs: 0.25rem;
   --space-2xs: 0.5rem;
@@ -160,6 +175,39 @@
   --ribbon-offset: 0px;
 }
 
+[data-theme="dark"] {
+  color-scheme: dark;
+  --color-ink: #f2efe6;
+  --color-ink-soft: rgba(242, 239, 230, 0.88);
+  --color-ink-muted: rgba(242, 239, 230, 0.72);
+  --color-ink-subtle: rgba(242, 239, 230, 0.5);
+  --surface-page: #0f1714;
+  --surface-canvas: #141f1b;
+  --surface-panel: rgba(20, 30, 26, 0.85);
+  --surface-card: rgba(24, 34, 30, 0.82);
+  --surface-subtle: rgba(30, 42, 36, 0.55);
+  --surface-overlay: rgba(4, 8, 6, 0.72);
+  --color-muted: rgba(242, 239, 230, 0.58);
+  --shadow-soft: 0 18px 48px -28px rgba(0, 0, 0, 0.55);
+  --shadow-floating: 0 32px 68px -24px rgba(0, 0, 0, 0.6);
+  --shadow-outline: 0 0 0 1px rgba(132, 180, 160, 0.35);
+  --card-bg-default: rgba(24, 34, 30, 0.82);
+  --card-border-default: rgba(190, 214, 202, 0.16);
+  --card-shadow-default: 0 32px 96px -52px rgba(0, 0, 0, 0.65);
+  --card-bg-moss: rgba(33, 45, 40, 0.82);
+  --card-border-moss: rgba(168, 202, 188, 0.2);
+  --card-shadow-moss: 0 28px 90px -52px rgba(0, 0, 0, 0.62);
+  --card-bg-linen: rgba(28, 37, 34, 0.78);
+  --card-border-linen: rgba(210, 198, 180, 0.2);
+  --card-shadow-linen: 0 24px 84px -52px rgba(0, 0, 0, 0.6);
+  --button-secondary-bg: rgba(24, 34, 30, 0.78);
+  --button-secondary-border: rgba(168, 202, 188, 0.32);
+  --button-secondary-color: rgba(242, 239, 230, 0.9);
+  --button-ghost-hover: rgba(242, 239, 230, 0.12);
+  --button-secondary-hover-bg: rgba(91, 127, 107, 0.32);
+  --button-secondary-border-hover: rgba(168, 202, 188, 0.45);
+}
+
 *,
 *::before,
 *::after {
@@ -169,6 +217,7 @@
 html {
   font-size: 100%;
   background: var(--surface-page);
+  scroll-behavior: smooth;
 }
 
 body {
@@ -184,6 +233,7 @@ body {
   letter-spacing: 0.01em;
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "kern" 1, "liga" 1, "clig" 1;
+  transition: background-color var(--transition-deliberate), color var(--transition-deliberate);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -195,6 +245,15 @@ body {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+
+  .reveal,
+  .page-transition,
+  .fade-media {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
 }
 
 main {
@@ -205,14 +264,17 @@ main {
 a {
   color: var(--color-moss);
   text-decoration: none;
-  text-decoration-thickness: 0.08em;
-  text-underline-offset: 0.28em;
-  transition: color var(--transition-base), text-decoration-color var(--transition-base);
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 1px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: color var(--transition-base), background-size var(--transition-slow);
 }
 
-a:hover {
+a:hover,
+a:focus-visible {
   color: var(--color-moss-strong);
-  text-decoration: underline;
+  background-size: 100% 1px;
 }
 
 a:focus-visible,
@@ -220,8 +282,9 @@ button:focus-visible,
 summary:focus-visible,
 input:focus-visible,
 textarea:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
+  outline: 2px solid var(--color-moss-500);
+  outline-offset: 3px;
+  box-shadow: none;
 }
 
 img,
@@ -230,6 +293,266 @@ video {
   display: block;
   max-width: 100%;
   height: auto;
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(var(--motion-distance-md));
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
+  will-change: transform, opacity;
+}
+
+.reveal.is-revealed {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.page-transition {
+  animation: pageFade 420ms var(--transition-base) both;
+}
+
+@keyframes pageFade {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-media {
+  opacity: 0;
+  transform: scale(1.025);
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
+  will-change: opacity, transform;
+}
+
+.fade-media.is-loaded {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.infographic-card {
+  --infographic-bg: var(--surface-card);
+  --infographic-border: rgba(19, 34, 30, 0.08);
+  --infographic-accent: var(--color-moss-600);
+  --infographic-marker: rgba(91, 127, 107, 0.14);
+  position: relative;
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 3rem);
+  padding: clamp(1.75rem, 6vw, 3.5rem);
+  background: var(--infographic-bg);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--infographic-border);
+  box-shadow: var(--shadow-floating);
+  color: var(--color-ink);
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform var(--transition-subtle), box-shadow var(--transition-subtle);
+}
+
+.infographic-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 40%, rgba(255, 255, 255, 0.18));
+  opacity: 0;
+  transition: opacity var(--transition-slow);
+  pointer-events: none;
+}
+
+.infographic-card:hover::after,
+.infographic-card:focus-within::after {
+  opacity: 1;
+}
+
+.infographic-card:hover,
+.infographic-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 36px 96px -48px rgba(19, 34, 30, 0.4);
+}
+
+.infographic-card--with-media {
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+}
+
+@media (max-width: 960px) {
+  .infographic-card--with-media {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.infographic-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.infographic-card__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--infographic-accent);
+}
+
+.infographic-card__title {
+  font-family: var(--font-display, "Fraunces", serif);
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+  line-height: 1.15;
+  margin: 0;
+}
+
+.infographic-card__summary {
+  font-size: var(--font-size-lead);
+  color: var(--color-ink-soft);
+  max-width: 60ch;
+}
+
+.infographic-card__list {
+  display: grid;
+  gap: clamp(1.1rem, 2.4vw, 1.8rem);
+  counter-reset: infographic-step;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.infographic-card__list-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.infographic-card__marker {
+  --size: 2.25rem;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 999px;
+  background: var(--infographic-marker);
+  position: relative;
+}
+
+.infographic-card__marker::after {
+  content: counter(infographic-step, decimal-leading-zero);
+  counter-increment: infographic-step;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--infographic-accent);
+  font-size: 0.85rem;
+}
+
+.infographic-card__item-title {
+  font-size: 1.1rem;
+  margin: 0 0 0.25rem;
+  color: var(--color-ink);
+}
+
+.infographic-card__item-description {
+  font-size: 0.95rem;
+  color: var(--color-ink-muted);
+  margin: 0;
+}
+
+.infographic-card__footnote {
+  font-size: 0.85rem;
+  color: var(--color-ink-subtle);
+  border-top: 1px solid rgba(19, 34, 30, 0.12);
+  padding-top: 1rem;
+  margin: 0;
+}
+
+.infographic-card__media {
+  position: relative;
+  min-height: 100%;
+  border-radius: var(--radius-2xl);
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.3), transparent 60%);
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  overflow: hidden;
+}
+
+.infographic-card__media > * {
+  width: min(100%, 320px);
+  max-width: 100%;
+  filter: drop-shadow(0 40px 80px rgba(19, 34, 30, 0.18));
+}
+
+.infographic-card--moss {
+  --infographic-bg: linear-gradient(140deg, rgba(241, 247, 244, 0.92), rgba(210, 230, 221, 0.9));
+  --infographic-border: rgba(91, 127, 107, 0.24);
+  --infographic-accent: var(--color-moss-600);
+  --infographic-marker: rgba(91, 127, 107, 0.18);
+}
+
+.infographic-card--spruce {
+  --infographic-bg: linear-gradient(140deg, rgba(20, 32, 28, 0.82), rgba(36, 54, 48, 0.85));
+  --infographic-border: rgba(154, 190, 181, 0.28);
+  --infographic-accent: #a8d2c3;
+  --infographic-marker: rgba(168, 210, 195, 0.22);
+  color: #f2efe6;
+}
+
+.infographic-card--spruce .infographic-card__summary,
+.infographic-card--spruce .infographic-card__item-description,
+.infographic-card--spruce .infographic-card__footnote {
+  color: rgba(242, 239, 230, 0.78);
+}
+
+.infographic-card--saffron {
+  --infographic-bg: linear-gradient(135deg, rgba(255, 244, 229, 0.95), rgba(243, 209, 151, 0.9));
+  --infographic-border: rgba(197, 138, 47, 0.32);
+  --infographic-accent: var(--color-saffron-600);
+  --infographic-marker: rgba(197, 138, 47, 0.2);
+}
+
+.infographic-card--linen {
+  --infographic-bg: rgba(250, 247, 242, 0.92);
+  --infographic-border: rgba(38, 33, 28, 0.12);
+  --infographic-accent: var(--color-fern-500);
+  --infographic-marker: rgba(109, 158, 120, 0.16);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .infographic-card,
+  .infographic-card::after {
+    transition: none;
+  }
+
+  .infographic-card:hover,
+  .infographic-card:focus-within {
+    transform: none;
+    box-shadow: var(--shadow-floating);
+  }
+}
+
+@media print {
+  .infographic-card {
+    box-shadow: none !important;
+    background: #ffffff !important;
+    color: #111111 !important;
+    border: 1px solid rgba(17, 24, 39, 0.16) !important;
+  }
+
+  .infographic-card::after {
+    display: none;
+  }
+
+  .infographic-card__marker {
+    background: rgba(17, 24, 39, 0.08);
+  }
+
+  .infographic-card__marker::after {
+    color: #111111;
+  }
 }
 
 .skip-link {
@@ -349,7 +672,6 @@ video {
   color: var(--color-moss-600);
   background: rgba(91, 127, 107, 0.16);
   box-shadow: 0 0 0 1px rgba(91, 127, 107, 0.2);
-  outline: none;
 }
 
 .site-nav__link--active {
@@ -361,7 +683,7 @@ video {
 .site-header__actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .search-trigger {
@@ -372,13 +694,15 @@ video {
   border: 1px solid rgba(91, 127, 107, 0.24);
   background: rgba(255, 255, 255, 0.7);
   color: rgba(19, 34, 30, 0.82);
-  padding: 0.45rem 0.85rem;
+  padding: 0.5rem 1rem;
   font-size: var(--font-size-sm);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
+  min-height: 2.75rem;
   transition: background var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base),
-    color var(--transition-base);
+    color var(--transition-base), transform var(--transition-subtle);
+  will-change: transform;
 }
 
 .search-trigger:hover,
@@ -387,7 +711,7 @@ video {
   border-color: rgba(91, 127, 107, 0.4);
   color: var(--color-moss-600);
   box-shadow: 0 0 0 1px rgba(91, 127, 107, 0.24);
-  outline: none;
+  transform: translateY(-1px);
 }
 
 .search-trigger__icon {
@@ -409,8 +733,8 @@ video {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: var(--radius-pill);
   border: 1px solid rgba(19, 34, 30, 0.12);
   background: rgba(255, 255, 255, 0.72);
@@ -423,7 +747,6 @@ video {
   background: rgba(91, 127, 107, 0.16);
   border-color: rgba(91, 127, 107, 0.4);
   color: var(--color-moss-600);
-  outline: none;
 }
 
 .site-nav__menu-icon {
@@ -435,6 +758,51 @@ video {
   .site-nav__menu-button {
     display: none;
   }
+}
+
+[data-theme="dark"] .site-header {
+  background: rgba(15, 23, 20, 0.86);
+  border-bottom-color: rgba(190, 214, 202, 0.16);
+  box-shadow: 0 10px 30px -22px rgba(0, 0, 0, 0.55);
+}
+
+[data-theme="dark"] .site-header--scrolled {
+  box-shadow: 0 16px 40px -24px rgba(0, 0, 0, 0.65);
+}
+
+[data-theme="dark"] .site-nav__link {
+  color: rgba(242, 239, 230, 0.88);
+}
+
+[data-theme="dark"] .site-nav__link:hover,
+[data-theme="dark"] .site-nav__link:focus-visible {
+  background: rgba(91, 127, 107, 0.3);
+  box-shadow: 0 0 0 1px rgba(168, 202, 188, 0.32);
+  color: rgba(236, 245, 240, 0.98);
+}
+
+[data-theme="dark"] .site-nav__link--active {
+  background: rgba(91, 127, 107, 0.32);
+  color: rgba(236, 245, 240, 0.98);
+}
+
+[data-theme="dark"] .search-trigger {
+  background: rgba(24, 34, 30, 0.82);
+  border-color: rgba(168, 202, 188, 0.28);
+  color: rgba(242, 239, 230, 0.88);
+}
+
+[data-theme="dark"] .site-nav__menu-button {
+  background: rgba(24, 34, 30, 0.82);
+  border-color: rgba(168, 202, 188, 0.24);
+  color: rgba(242, 239, 230, 0.88);
+}
+
+[data-theme="dark"] .site-nav__menu-button:hover,
+[data-theme="dark"] .site-nav__menu-button:focus-visible {
+  background: rgba(91, 127, 107, 0.26);
+  border-color: rgba(168, 202, 188, 0.45);
+  color: rgba(236, 245, 240, 0.98);
 }
 
 .site-nav__overlay {
@@ -480,8 +848,8 @@ video {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.75rem;
+  height: 2.75rem;
   border-radius: var(--radius-pill);
   border: 1px solid rgba(19, 34, 30, 0.12);
   background: rgba(255, 255, 255, 0.85);
@@ -494,7 +862,7 @@ video {
 .site-nav__overlay-close:focus-visible {
   background: rgba(91, 127, 107, 0.18);
   border-color: rgba(91, 127, 107, 0.45);
-  outline: none;
+
 }
 
 .site-nav__overlay-links {
@@ -520,7 +888,29 @@ video {
   border-color: rgba(91, 127, 107, 0.32);
   background: rgba(91, 127, 107, 0.12);
   transform: translateX(4px);
-  outline: none;
+}
+
+[data-theme="dark"] .site-nav__overlay {
+  background: rgba(4, 8, 6, 0.78);
+}
+
+[data-theme="dark"] .site-nav__overlay-panel {
+  background: rgba(20, 30, 26, 0.92);
+  border-color: rgba(168, 202, 188, 0.22);
+  color: rgba(242, 239, 230, 0.9);
+  box-shadow: 0 40px 120px -60px rgba(0, 0, 0, 0.65);
+}
+
+[data-theme="dark"] .site-nav__overlay-link {
+  border-color: rgba(168, 202, 188, 0.18);
+  background: rgba(28, 39, 34, 0.86);
+  color: rgba(242, 239, 230, 0.92);
+}
+
+[data-theme="dark"] .site-nav__overlay-link:hover,
+[data-theme="dark"] .site-nav__overlay-link:focus-visible {
+  border-color: rgba(168, 202, 188, 0.35);
+  background: rgba(91, 127, 107, 0.28);
 }
 
 .site-nav__overlay-link-label {
@@ -578,7 +968,7 @@ video {
   border-color: rgba(91, 127, 107, 0.45);
   background: rgba(91, 127, 107, 0.16);
   box-shadow: var(--shadow-focus);
-  outline: none;
+
 }
 
 .social-links__icon {
@@ -638,7 +1028,6 @@ video {
   border-color: rgba(91, 127, 107, 0.45);
   color: var(--color-moss-strong);
   box-shadow: var(--shadow-focus);
-  outline: none;
 }
 
 .search-trigger__icon {
@@ -708,7 +1097,7 @@ video {
 .search-modal__close:hover,
 .search-modal__close:focus-visible {
   background: rgba(91, 127, 107, 0.28);
-  outline: none;
+
 }
 
 .search-modal__content {
@@ -818,7 +1207,7 @@ details[open] .site-nav__panel {
 .site-footer__nav a:hover,
 .site-footer__nav a:focus-visible {
   color: #f2c879;
-  outline: none;
+
 }
 
 .site-footer__subtitle {
@@ -918,7 +1307,174 @@ details[open] .site-nav__panel {
 .site-footer__meta a:hover,
 .site-footer__meta a:focus-visible {
   color: #f2c879;
-  outline: none;
+
+}
+
+.recipe-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  border-radius: var(--radius-2xl);
+  background: var(--surface-card);
+  border: 1px solid rgba(19, 34, 30, 0.08);
+  box-shadow: var(--shadow-soft);
+  transition: transform var(--transition-subtle), box-shadow var(--transition-subtle);
+}
+
+.recipe-card:hover,
+.recipe-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 72px -48px rgba(19, 34, 30, 0.42);
+}
+
+.recipe-card__media {
+  position: relative;
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  min-height: clamp(220px, 32vw, 320px);
+  display: block;
+}
+
+.recipe-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.recipe-card__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--color-moss-600);
+  margin-bottom: 0.5rem;
+}
+
+.recipe-card__title {
+  font-family: var(--font-display, "Fraunces", serif);
+  font-size: clamp(1.6rem, 2.6vw, 2.1rem);
+  margin: 0;
+}
+
+.recipe-card__title a {
+  color: inherit;
+  background-image: none;
+}
+
+.recipe-card__title a:hover,
+.recipe-card__title a:focus-visible {
+  color: var(--color-moss-700);
+  text-decoration: none;
+}
+
+.recipe-card__description {
+  font-size: 1rem;
+  color: var(--color-ink-soft);
+  margin: 0;
+}
+
+.recipe-card__meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: var(--radius-xl);
+  background: rgba(241, 247, 244, 0.7);
+  margin: 0;
+}
+
+.recipe-card__meta div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.recipe-card__meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+  color: var(--color-moss-600);
+}
+
+.recipe-card__meta dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.recipe-card__cta {
+  align-self: flex-start;
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.85rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(91, 127, 107, 0.32);
+  background: rgba(91, 127, 107, 0.12);
+  color: var(--color-moss-700);
+  transition: background var(--transition-subtle), color var(--transition-subtle), border var(--transition-subtle);
+}
+
+.recipe-card__cta:hover,
+.recipe-card__cta:focus-visible {
+  background: rgba(91, 127, 107, 0.18);
+  border-color: rgba(91, 127, 107, 0.42);
+  color: var(--color-moss-800);
+}
+
+.recipe-card-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.recipe-card-grid__item {
+  list-style: none;
+}
+
+@media (max-width: 900px) {
+  .recipe-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recipe-card,
+  .recipe-card__cta {
+    transition: none;
+  }
+
+  .recipe-card:hover,
+  .recipe-card:focus-within {
+    transform: none;
+    box-shadow: var(--shadow-soft);
+  }
+}
+
+@media print {
+  .recipe-card {
+    box-shadow: none !important;
+    background: #ffffff !important;
+    border: 1px solid rgba(17, 24, 39, 0.16) !important;
+  }
+
+  .recipe-card__cta {
+    display: none;
+  }
+
+  .recipe-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+  }
 }
 
 .recipe-layout {
@@ -990,6 +1546,18 @@ details[open] .site-nav__panel {
 .recipe-layout__meta strong {
   font-size: 1.05rem;
   color: var(--color-ink);
+}
+
+[data-theme="dark"] .recipe-layout__meta div {
+  background: rgba(91, 127, 107, 0.26);
+}
+
+[data-theme="dark"] .recipe-layout__meta span {
+  color: rgba(242, 239, 230, 0.7);
+}
+
+[data-theme="dark"] .recipe-layout__meta strong {
+  color: rgba(242, 239, 230, 0.92);
 }
 
 .recipe-layout__jump {
@@ -1066,9 +1634,9 @@ details[open] .site-nav__panel {
 .recipe-layout__steps li {
   padding: 1.25rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(19, 34, 30, 0.08);
-  background: rgba(255, 255, 255, 0.82);
-  box-shadow: 0 26px 72px -52px rgba(19, 34, 30, 0.4);
+  border: 1px solid var(--card-border-default);
+  background: var(--card-bg-default);
+  box-shadow: var(--card-shadow-default);
 }
 
 .recipe-layout__step-heading {
@@ -1092,20 +1660,20 @@ details[open] .site-nav__panel {
 
 .recipe-layout__steps p {
   margin: 0;
-  color: rgba(19, 34, 30, 0.82);
+  color: var(--color-ink);
   line-height: 1.6;
 }
 
 .recipe-layout__tips {
   border-radius: 1.75rem;
-  border: 1px solid rgba(19, 34, 30, 0.08);
-  background: rgba(240, 243, 240, 0.65);
+  border: 1px solid var(--card-border-moss);
+  background: var(--card-bg-moss);
   padding: clamp(1.5rem, 4vw, 2rem);
 }
 
 .recipe-layout__tips-body {
   margin-top: 0.75rem;
-  color: rgba(19, 34, 30, 0.78);
+  color: var(--color-ink-soft);
   font-size: 0.95rem;
   line-height: 1.6;
 }
@@ -1116,45 +1684,78 @@ details[open] .site-nav__panel {
   }
 
   body {
-    background: #ffffff;
-    color: #111111;
+    background: #ffffff !important;
+    color: #111111 !important;
+    font-size: 12pt;
   }
 
   .site-header,
   .site-footer,
   .newsletter-ribbon,
   .search-modal,
-  .site-nav__overlay {
+  .site-nav__overlay,
+  .theme-toggle {
     display: none !important;
   }
 
+  .page-transition,
+  .site-main,
   .recipe-layout {
+    animation: none !important;
+    transform: none !important;
+  }
+
+  .recipe-layout {
+    padding: 0;
     gap: 1.5rem;
   }
 
-  .recipe-layout__hero {
-    grid-template-columns: 1fr;
+  .recipe-layout ~ * {
+    display: none !important;
   }
 
-  .recipe-layout__image {
+  .recipe-layout__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    gap: 1.5rem;
+  }
+
+  .recipe-layout__image,
+  .recipe-layout__image::after {
+    position: relative;
     aspect-ratio: auto;
-    height: 220px;
+    height: auto;
     box-shadow: none;
+  }
+
+  .recipe-layout__content {
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.65fr);
+    gap: 1.5rem;
+  }
+
+  .recipe-layout__card,
+  .recipe-layout__steps,
+  .recipe-layout__tips {
+    background: #ffffff !important;
+    color: #111111 !important;
+    border: 1px solid rgba(17, 24, 39, 0.12) !important;
+    box-shadow: none !important;
   }
 
   .recipe-layout__meta div {
     background: #f5f1eb;
-  }
-
-  .recipe-layout__steps li,
-  .recipe-layout__tips {
-    background: #ffffff;
-    box-shadow: none;
-    border-color: #d9d4cc;
+    color: #111111;
   }
 
   .recipe-layout__steps ol {
     gap: 1rem;
+  }
+
+  a {
+    color: inherit !important;
+    text-decoration: underline !important;
+    background: none !important;
   }
 }
 
@@ -1409,7 +2010,7 @@ details[open] .site-nav__panel {
 .newsletter-ribbon__close:focus-visible {
   background: rgba(91, 127, 107, 0.24);
   color: var(--color-moss-strong);
-  outline: none;
+
   box-shadow: var(--shadow-focus);
 }
 
@@ -1725,7 +2326,7 @@ details[open] .site-nav__panel {
 
 .contact-form__field input:focus-visible,
 .contact-form__field textarea:focus-visible {
-  outline: none;
+
   border-color: var(--color-moss);
   box-shadow: 0 0 0 3px rgba(91, 127, 107, 0.25);
 }
@@ -2073,6 +2674,10 @@ details[open] .site-nav__panel {
   gap: 1.75rem;
 }
 
+.home-newsletter {
+  width: 100%;
+}
+
 .section-header {
   display: flex;
   flex-wrap: wrap;
@@ -2233,7 +2838,7 @@ details[open] .site-nav__panel {
 .post-toc__item a:hover,
 .post-toc__item a:focus-visible {
   color: var(--color-moss-strong);
-  outline: none;
+
 }
 
 .post-toc__item--level-3 {
@@ -2292,7 +2897,7 @@ details[open] .site-nav__panel {
   border-color: rgba(91, 127, 107, 0.45);
   background: rgba(91, 127, 107, 0.16);
   box-shadow: var(--shadow-focus);
-  outline: none;
+
 }
 
 .post-poll {
@@ -2354,7 +2959,7 @@ details[open] .site-nav__panel {
   border-color: rgba(91, 127, 107, 0.45);
   background: rgba(91, 127, 107, 0.16);
   box-shadow: var(--shadow-focus);
-  outline: none;
+
 }
 
 .post-poll__option--selected {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import Script from "next/script";
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
@@ -33,7 +34,30 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning data-theme="light">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link rel="preload" as="image" href="/images/recipes/moon-milk.svg" type="image/svg+xml" />
+        <Script id="theme-initializer" strategy="beforeInteractive">
+          {`
+            (function () {
+              const storageKey = "gl-theme";
+              try {
+                const root = document.documentElement;
+                const stored = window.localStorage.getItem(storageKey);
+                const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+                const resolved = stored === "dark" || stored === "light" ? stored : systemPrefersDark ? "dark" : "light";
+                root.dataset.theme = resolved;
+                root.style.colorScheme = resolved === "dark" ? "dark" : "light";
+              } catch (error) {
+                document.documentElement.dataset.theme = "light";
+                document.documentElement.style.colorScheme = "light";
+              }
+            })();
+          `}
+        </Script>
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -7,80 +7,160 @@ const WIDTH = 1200;
 const HEIGHT = 630;
 
 const displayFontFamily = '"Fraunces", "Times New Roman", serif';
-const bodyFontFamily =
-  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+const bodyFontFamily = '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+const variants = {
+  editorial: {
+    background: "linear-gradient(135deg, #f5f1eb 0%, #e3ede6 100%)",
+    panel: "rgba(250, 247, 242, 0.9)",
+    accent: "#5B7F6B",
+    eyebrow: "Journal",
+  },
+  commerce: {
+    background: "linear-gradient(135deg, #101d18 0%, #1d2b26 100%)",
+    panel: "rgba(17, 27, 23, 0.78)",
+    accent: "#E2C289",
+    eyebrow: "Shop",
+  },
+} as const;
+
+type VariantName = keyof typeof variants;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
+  const rawVariant = (searchParams.get("variant") ?? "editorial") as VariantName;
+  const variant: VariantName = rawVariant in variants ? rawVariant : "editorial";
+  const theme = variants[variant];
+
   const title = searchParams.get("title")?.slice(0, 140) || "Grounded Living";
   const subtitle = searchParams.get("subtitle")?.slice(0, 160) ?? null;
-  const type = searchParams.get("type") === "post" ? "Journal" : "Page";
+  const eyebrow = searchParams.get("eyebrow")?.slice(0, 32) ?? theme.eyebrow;
+  const tag = searchParams.get("tag")?.slice(0, 32) ?? null;
 
   return new ImageResponse(
     (
       <div
         style={{
+          width: WIDTH,
+          height: HEIGHT,
           display: "flex",
           flexDirection: "column",
           justifyContent: "space-between",
-          width: WIDTH,
-          height: HEIGHT,
-          padding: 80,
-          backgroundColor: "#F8F5F2",
-          color: "#0F172A",
+          backgroundImage: theme.background,
+          padding: 72,
+          color: variant === "commerce" ? "#F5F1E6" : "#13221E",
         }}
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-          <div style={{ fontFamily: displayFontFamily, fontSize: 40, fontWeight: 700 }}>
-            Grounded Living
-          </div>
-          <div
-            style={{
-              fontFamily: bodyFontFamily,
-              fontSize: 24,
-              textTransform: "uppercase",
-              letterSpacing: 6,
-              color: "#5B7F6B",
-            }}
-          >
-            {type}
-          </div>
-        </div>
-        <div
-          style={{
-            flexGrow: 1,
-            display: "flex",
-            alignItems: "center",
-          }}
-        >
-          <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div
               style={{
+                fontFamily: bodyFontFamily,
+                fontSize: 22,
+                textTransform: "uppercase",
+                letterSpacing: 8,
+                color: theme.accent,
+              }}
+            >
+              {eyebrow}
+            </div>
+            <div style={{ fontFamily: displayFontFamily, fontSize: 38, fontWeight: 700 }}>Grounded Living</div>
+          </div>
+          {tag ? (
+            <div
+              style={{
+                fontFamily: bodyFontFamily,
+                fontSize: 20,
+                padding: "8px 20px",
+                borderRadius: 999,
+                border: `2px solid ${theme.accent}`,
+                color: theme.accent,
+                backgroundColor: variant === "commerce" ? "rgba(226, 194, 137, 0.12)" : "rgba(91, 127, 107, 0.12)",
+              }}
+            >
+              {tag}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 24,
+              padding: "48px 56px",
+              backgroundColor: theme.panel,
+              borderRadius: 48,
+              backdropFilter: "blur(8px)",
+              border: `1px solid ${variant === "commerce" ? "rgba(226, 194, 137, 0.24)" : "rgba(19,34,30,0.1)"}`,
+              boxShadow:
+                variant === "commerce"
+                  ? "0 40px 120px -60px rgba(0, 0, 0, 0.45)"
+                  : "0 36px 110px -60px rgba(19, 34, 30, 0.36)",
+            }}
+          >
+            <h1
+              style={{
+                margin: 0,
                 fontFamily: displayFontFamily,
-                fontSize: 90,
+                fontSize: 84,
+                lineHeight: 1.08,
                 fontWeight: 700,
-                lineHeight: 1.1,
-                maxWidth: 900,
+                letterSpacing: -2,
+                maxWidth: 880,
               }}
             >
               {title}
-            </div>
+            </h1>
             {subtitle ? (
-              <div
+              <p
                 style={{
+                  margin: 0,
                   fontFamily: bodyFontFamily,
                   fontSize: 32,
-                  maxWidth: 720,
-                  lineHeight: 1.4,
-                  color: "#334155",
+                  lineHeight: 1.45,
+                  maxWidth: 760,
+                  color: variant === "commerce" ? "rgba(245, 241, 230, 0.78)" : "rgba(19, 34, 30, 0.72)",
                 }}
               >
                 {subtitle}
-              </div>
+              </p>
             ) : null}
           </div>
         </div>
-        <div style={{ width: 120, height: 8, backgroundColor: "#5B7F6B" }} />
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontFamily: bodyFontFamily,
+            fontSize: 22,
+            letterSpacing: 2,
+          }}
+        >
+          <span>groundedliving.org</span>
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 12,
+              color: theme.accent,
+              fontWeight: 600,
+            }}
+          >
+            <span style={{ display: "inline-block", width: 64, height: 4, backgroundColor: theme.accent, borderRadius: 999 }} />
+            Rooted rituals & modern commerce
+          </span>
+        </div>
       </div>
     ),
     {

--- a/components/blog/HeroCarousel.module.css
+++ b/components/blog/HeroCarousel.module.css
@@ -118,6 +118,14 @@
   object-fit: cover;
   width: 100%;
   height: 100%;
+  opacity: 0;
+  transform: scale(1.02);
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
+}
+
+.mediaImage.is-loaded {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .dots {

--- a/components/blog/HeroCarousel.tsx
+++ b/components/blog/HeroCarousel.tsx
@@ -46,7 +46,13 @@ export function HeroCarousel({ posts, intervalMs = 7000 }: HeroCarouselProps) {
   }
 
   return (
-    <section className={styles.hero} aria-label="Featured posts">
+    <section
+      className={styles.hero}
+      aria-label="Featured posts"
+      role="region"
+      aria-roledescription="carousel"
+      aria-live="polite"
+    >
       <div className={styles.gradient} aria-hidden />
       <div className={styles.slides}>
         {items.map((item, index) => {
@@ -72,6 +78,9 @@ export function HeroCarousel({ posts, intervalMs = 7000 }: HeroCarouselProps) {
               key={item.id}
               className={`${styles.slide} ${isActive ? styles.active : styles.inactive}`}
               aria-hidden={!isActive}
+              role="group"
+              aria-roledescription="slide"
+              aria-label={`Slide ${index + 1} of ${items.length}`}
             >
               <div className={styles.slideInner}>
                 <div className={styles.copy}>
@@ -94,6 +103,7 @@ export function HeroCarousel({ posts, intervalMs = 7000 }: HeroCarouselProps) {
                       fetchPriority={index === 0 ? "high" : "auto"}
                       loading={index === 0 ? "eager" : "lazy"}
                       className={styles.mediaImage}
+                      onLoadingComplete={(img) => img.classList.add("is-loaded")}
                     />
                   </div>
                 ) : null}
@@ -102,7 +112,7 @@ export function HeroCarousel({ posts, intervalMs = 7000 }: HeroCarouselProps) {
           );
         })}
       </div>
-      <div className={styles.dots}>
+      <div className={styles.dots} role="tablist" aria-label="Featured stories selector">
         {items.map((item, index) => (
           <button
             type="button"
@@ -111,6 +121,8 @@ export function HeroCarousel({ posts, intervalMs = 7000 }: HeroCarouselProps) {
             className={`${styles.dot} ${index === activeIndex ? styles.dotActive : ""}`}
             aria-label={`Show slide ${index + 1}`}
             aria-pressed={index === activeIndex}
+            role="tab"
+            aria-selected={index === activeIndex}
           />
         ))}
       </div>

--- a/components/blog/InfographicCard.tsx
+++ b/components/blog/InfographicCard.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+export type InfographicTheme = "moss" | "spruce" | "saffron" | "linen";
+
+export interface InfographicCardItem {
+  title: string;
+  description?: string | null;
+}
+
+export interface InfographicCardProps {
+  id?: string;
+  eyebrow?: string | null;
+  title: string;
+  summary?: string | null;
+  items: InfographicCardItem[];
+  footnote?: string | null;
+  theme?: InfographicTheme;
+  className?: string;
+  media?: ReactNode;
+}
+
+const themeClassMap: Record<InfographicTheme, string> = {
+  moss: "infographic-card--moss",
+  spruce: "infographic-card--spruce",
+  saffron: "infographic-card--saffron",
+  linen: "infographic-card--linen",
+};
+
+export function InfographicCard({
+  id,
+  eyebrow,
+  title,
+  summary,
+  items,
+  footnote,
+  theme = "linen",
+  className,
+  media,
+}: InfographicCardProps) {
+  const hasMedia = Boolean(media);
+  const headingId = (id && sanitizeId(id)) || slugifyId(title);
+
+  return (
+    <section
+      className={cn("infographic-card", themeClassMap[theme], hasMedia && "infographic-card--with-media", className)}
+      aria-labelledby={headingId}
+      role="region"
+    >
+      <div className="infographic-card__body">
+        {eyebrow ? (
+          <p className="infographic-card__eyebrow" aria-label={eyebrow}>
+            {eyebrow}
+          </p>
+        ) : null}
+        <h2 id={headingId} className="infographic-card__title">
+          {title}
+        </h2>
+        {summary ? <p className="infographic-card__summary">{summary}</p> : null}
+        <ol className="infographic-card__list">
+          {items.map((item) => (
+            <li key={item.title} className="infographic-card__list-item">
+              <div className="infographic-card__marker" aria-hidden />
+              <div>
+                <h3 className="infographic-card__item-title">{item.title}</h3>
+                {item.description ? <p className="infographic-card__item-description">{item.description}</p> : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+        {footnote ? <p className="infographic-card__footnote">{footnote}</p> : null}
+      </div>
+      {hasMedia ? <div className="infographic-card__media">{media}</div> : null}
+    </section>
+  );
+}
+
+function slugifyId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function sanitizeId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "-");
+}

--- a/components/blog/PostCard.module.css
+++ b/components/blog/PostCard.module.css
@@ -25,11 +25,18 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform var(--transition-slow);
+  transform: scale(1.02);
+  opacity: 0;
+  transition: opacity var(--transition-slow), transform var(--transition-slow);
 }
 
 .coverLink:hover .coverImage {
   transform: scale(1.05);
+}
+
+.coverImage.is-loaded {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .coverPlaceholder {

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 
@@ -30,6 +32,7 @@ export function PostCard({ post }: PostCardProps) {
             sizes="(max-width: 639px) 100vw, (max-width: 1023px) 50vw, 33vw"
             loading="lazy"
             className={styles.coverImage}
+            onLoadingComplete={(img) => img.classList.add("is-loaded")}
           />
         ) : (
           <div className={styles.coverPlaceholder} aria-hidden>

--- a/components/recipes/RecipeCard.tsx
+++ b/components/recipes/RecipeCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils/cn";
+
+export interface RecipeCardProps {
+  title: string;
+  description: string;
+  href: string;
+  image: {
+    src: string;
+    alt: string;
+  };
+  meta: {
+    prep: string;
+    cook: string;
+    yield: string;
+  };
+  className?: string;
+}
+
+export function RecipeCard({ title, description, href, image, meta, className }: RecipeCardProps) {
+  return (
+    <article className={cn("recipe-card", className)}>
+      <Link href={href} className="recipe-card__media" aria-label={`View recipe for ${title}`}>
+        <Image
+          src={image.src}
+          alt={image.alt}
+          fill
+          className="fade-media object-cover"
+          sizes="(min-width: 1024px) 320px, (min-width: 768px) 45vw, 90vw"
+          onLoadingComplete={(img) => img.classList.add("is-loaded")}
+        />
+      </Link>
+      <div className="recipe-card__body">
+        <p className="recipe-card__eyebrow">Kitchen ritual</p>
+        <h3 className="recipe-card__title">
+          <Link href={href}>{title}</Link>
+        </h3>
+        <p className="recipe-card__description">{description}</p>
+        <dl className="recipe-card__meta">
+          <div>
+            <dt>Prep</dt>
+            <dd>{meta.prep}</dd>
+          </div>
+          <div>
+            <dt>Cook</dt>
+            <dd>{meta.cook}</dd>
+          </div>
+          <div>
+            <dt>Yield</dt>
+            <dd>{meta.yield}</dd>
+          </div>
+        </dl>
+        <Link href={href} className="recipe-card__cta">
+          Print &amp; save recipe
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/components/recipes/RecipeLayout.tsx
+++ b/components/recipes/RecipeLayout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import type { ReactNode } from "react";
 
@@ -49,7 +51,15 @@ export function RecipeLayout({
     <article className="recipe-layout" aria-labelledby="recipe-title">
       <div className="recipe-layout__hero">
         <div className="recipe-layout__image">
-          <Image src={hero.src} alt={hero.alt} fill className="object-cover" sizes="(min-width: 1024px) 640px, 100vw" />
+          <Image
+            src={hero.src}
+            alt={hero.alt}
+            fill
+            className="fade-media object-cover"
+            sizes="(min-width: 1024px) 640px, 100vw"
+            priority
+            onLoadingComplete={(img) => img.classList.add("is-loaded")}
+          />
         </div>
         <div className="recipe-layout__intro">
           <p className="recipe-layout__eyebrow">Seasonal Recipe</p>
@@ -76,6 +86,31 @@ export function RecipeLayout({
           <a
             href="#recipe-card"
             className={buttonClassNames({ variant: "secondary", size: "md", className: "recipe-layout__jump" })}
+            onClick={(event) => {
+              if (typeof document === "undefined") {
+                return;
+              }
+              const target = document.getElementById("recipe-card");
+              if (!target) {
+                return;
+              }
+              event.preventDefault();
+              const previousTabIndex = target.getAttribute("tabindex");
+              target.setAttribute("tabindex", "-1");
+              target.scrollIntoView({ behavior: "smooth", block: "start" });
+              target.focus({ preventScroll: true });
+              target.addEventListener(
+                "blur",
+                () => {
+                  if (previousTabIndex === null) {
+                    target.removeAttribute("tabindex");
+                  } else {
+                    target.setAttribute("tabindex", previousTabIndex);
+                  }
+                },
+                { once: true },
+              );
+            }}
           >
             Jump to recipe
           </a>

--- a/components/shop/ProductCard.tsx
+++ b/components/shop/ProductCard.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/ui/Reveal";
 import type { ShopProduct } from "@project-types/shop";
 import { formatCurrency } from "@/lib/utils/currency";
 
@@ -13,7 +16,10 @@ export function ProductCard({ product }: ProductCardProps) {
   const price = formatCurrency(product.priceCents, product.priceCurrency);
 
   return (
-    <li className="group flex flex-col overflow-hidden rounded-3xl border border-ink/10 bg-white/90 shadow-[0_24px_60px_-30px_rgba(19,34,30,0.4)] transition hover:-translate-y-1 hover:shadow-[0_32px_80px_-36px_rgba(19,34,30,0.35)]">
+    <Reveal
+      as="li"
+      className="group flex flex-col overflow-hidden rounded-3xl border border-[color:var(--card-border-default)] bg-[var(--card-bg-default)] shadow-[var(--card-shadow-default)] transition-transform duration-subtle ease-[cubic-bezier(0.33,1,0.68,1)] motion-safe:will-change-transform hover:-translate-y-[6px] hover:shadow-[0_32px_80px_-36px_rgba(19,34,30,0.35)] focus-within:-translate-y-[6px] focus-within:shadow-[0_32px_80px_-36px_rgba(19,34,30,0.35)]"
+    >
       <Link href={`/shop/${product.slug}`} className="flex flex-1 flex-col">
         <div className="relative aspect-[5/4] w-full">
           <Image
@@ -21,8 +27,11 @@ export function ProductCard({ product }: ProductCardProps) {
             alt={product.image.alt}
             fill
             sizes="(min-width: 1024px) 420px, (min-width: 768px) 45vw, 90vw"
-            className="object-cover"
+            className="fade-media object-cover"
             priority={false}
+            onLoadingComplete={(img) => {
+              img.classList.add("is-loaded");
+            }}
           />
         </div>
         <div className="flex flex-1 flex-col gap-4 p-6">
@@ -56,6 +65,6 @@ export function ProductCard({ product }: ProductCardProps) {
           </div>
         </div>
       </Link>
-    </li>
+    </Reveal>
   );
 }

--- a/components/site/Footer.tsx
+++ b/components/site/Footer.tsx
@@ -6,6 +6,7 @@ import { SocialLinks } from "@/components/site/SocialLinks";
 import { Logo } from "@/components/site/Logo";
 import { footerNavigation, primaryNavigation } from "@/lib/navigation/primary";
 import { getCategories } from "@/lib/contentful";
+import { getAllProducts } from "@/lib/shop/products";
 
 const DEFAULT_CONTACT_EMAIL = "hello@groundedliving.org";
 
@@ -13,12 +14,20 @@ export async function Footer() {
   const year = new Date().getFullYear();
   const contactEmail = process.env.NEXT_PUBLIC_CONTACT_EMAIL ?? DEFAULT_CONTACT_EMAIL;
   let categories: Awaited<ReturnType<typeof getCategories>> = [];
+  let products: ReturnType<typeof getAllProducts> = [];
 
   try {
     categories = (await getCategories()).slice(0, 4);
   } catch (error) {
     console.warn("Failed to load categories for footer navigation", error);
     categories = [];
+  }
+
+  try {
+    products = getAllProducts().slice(0, 3);
+  } catch (error) {
+    console.warn("Failed to load shop products for footer navigation", error);
+    products = [];
   }
 
   return (
@@ -54,6 +63,18 @@ export async function Footer() {
                   {categories.map((category) => (
                     <li key={category.slug}>
                       <Link href={`/categories/${category.slug}`}>{category.name}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            ) : null}
+            {products.length ? (
+              <nav aria-label="Shop highlights" className="site-footer__nav">
+                <h3 className="site-footer__subtitle">Shop highlights</h3>
+                <ul>
+                  {products.map((product) => (
+                    <li key={product.slug}>
+                      <Link href={`/shop/${product.slug}`}>{product.name}</Link>
                     </li>
                   ))}
                 </ul>

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -10,6 +10,7 @@ import { SearchResults } from "@/components/search/SearchResults";
 import { Container } from "@/components/ui/Container";
 import { SocialLinks } from "@/components/site/SocialLinks";
 import { Logo } from "@/components/site/Logo";
+import { ThemeToggle } from "@/components/site/ThemeToggle";
 import { primaryNavigation } from "@/lib/navigation/primary";
 
 const SEARCH_MODAL_RESULTS_ID = "header-search-results";
@@ -181,6 +182,7 @@ export function Header() {
           ))}
         </nav>
         <div className="site-header__actions">
+          <ThemeToggle className="site-header__theme-toggle" />
           <button
             type="button"
             className="search-trigger"

--- a/components/site/LiveAnnouncer.tsx
+++ b/components/site/LiveAnnouncer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ANNOUNCE_EVENT_NAME, type AnnounceEventDetail } from "@/lib/a11y/announcer";
+
+type ActiveMessage = {
+  message: string;
+  politeness: AnnounceEventDetail["politeness"];
+};
+
+const CLEAR_TIMEOUT = 4000;
+
+export function LiveAnnouncer() {
+  const [active, setActive] = useState<ActiveMessage>({ message: "", politeness: "polite" });
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<AnnounceEventDetail>).detail;
+      if (!detail?.message) {
+        return;
+      }
+      setActive({ message: detail.message, politeness: detail.politeness ?? "polite" });
+    };
+
+    document.addEventListener(ANNOUNCE_EVENT_NAME, handler as EventListener);
+    return () => document.removeEventListener(ANNOUNCE_EVENT_NAME, handler as EventListener);
+  }, []);
+
+  useEffect(() => {
+    if (!active.message) {
+      return undefined;
+    }
+    const timeout = window.setTimeout(() => {
+      setActive((current) => ({ ...current, message: "" }));
+    }, CLEAR_TIMEOUT);
+
+    return () => window.clearTimeout(timeout);
+  }, [active.message]);
+
+  return (
+    <>
+      <div className="sr-only" aria-live="polite" aria-atomic role="status">
+        {active.politeness === "polite" ? active.message : ""}
+      </div>
+      <div className="sr-only" aria-live="assertive" aria-atomic role="alert">
+        {active.politeness === "assertive" ? active.message : ""}
+      </div>
+    </>
+  );
+}

--- a/components/site/PageTransition.tsx
+++ b/components/site/PageTransition.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+interface PageTransitionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function PageTransition({ children, className }: PageTransitionProps) {
+  const pathname = usePathname();
+
+  return (
+    <div key={pathname} className={cn("page-transition", className)}>
+      {children}
+    </div>
+  );
+}

--- a/components/site/ThemeProvider.tsx
+++ b/components/site/ThemeProvider.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+export type ThemeMode = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  toggleTheme: () => void;
+  setTheme: (theme: ThemeMode) => void;
+  useSystemPreference: () => void;
+  isSystemPreference: boolean;
+}
+
+const STORAGE_KEY = "gl-theme";
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function applyTheme(theme: ThemeMode) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme === "dark" ? "dark" : "light";
+}
+
+function readStoredTheme(): ThemeMode | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored === "light" || stored === "dark" ? stored : null;
+}
+
+function resolveSystemTheme(): ThemeMode {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeMode>(() => {
+    if (typeof document === "undefined") {
+      return "light";
+    }
+
+    const current = document.documentElement.dataset.theme;
+    return current === "dark" ? "dark" : "light";
+  });
+  const [isSystemPreference, setSystemPreference] = useState<boolean>(() => readStoredTheme() === null);
+
+  useEffect(() => {
+    const storedTheme = readStoredTheme();
+    const systemTheme = resolveSystemTheme();
+    const resolved = storedTheme ?? systemTheme;
+    setThemeState(resolved);
+    applyTheme(resolved);
+    setSystemPreference(storedTheme === null);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (readStoredTheme() !== null) {
+        return;
+      }
+      const next = event.matches ? "dark" : "light";
+      setThemeState(next);
+      applyTheme(next);
+      setSystemPreference(true);
+    };
+
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, []);
+
+  const setTheme = useCallback((next: ThemeMode) => {
+    setThemeState(next);
+    setSystemPreference(false);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    }
+    applyTheme(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  }, [setTheme, theme]);
+
+  const useSystemPreference = useCallback(() => {
+    const systemTheme = resolveSystemTheme();
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+    setSystemPreference(true);
+    setThemeState(systemTheme);
+    applyTheme(systemTheme);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, toggleTheme, setTheme, useSystemPreference, isSystemPreference }),
+    [theme, toggleTheme, setTheme, useSystemPreference, isSystemPreference],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/components/site/ThemeToggle.tsx
+++ b/components/site/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, SunMedium } from "lucide-react";
+
+import { useTheme } from "@/components/site/ThemeProvider";
+import { cn } from "@/lib/utils/cn";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useTheme();
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const isDark = theme === "dark";
+  const label = isDark ? "Switch to light theme" : "Switch to dark theme";
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "theme-toggle",
+        "relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--button-secondary-border)] bg-[color:var(--surface-subtle)] text-[color:var(--color-ink)] transition-transform duration-subtle ease-[cubic-bezier(0.33,1,0.68,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-moss-500",
+        className,
+      )}
+      onClick={toggleTheme}
+      aria-pressed={isDark}
+      aria-label={label}
+      title={label}
+    >
+      <span className="sr-only">{label}</span>
+      <SunMedium
+        aria-hidden
+        className={cn(
+          "absolute h-5 w-5 transition-all duration-300",
+          hasMounted && isDark ? "scale-50 opacity-0" : "scale-100 opacity-100",
+        )}
+      />
+      <Moon
+        aria-hidden
+        className={cn(
+          "absolute h-5 w-5 transition-all duration-300",
+          hasMounted && isDark ? "scale-100 opacity-100" : "scale-50 opacity-0",
+        )}
+      />
+    </button>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -12,15 +12,15 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const baseClasses =
-  "inline-flex items-center justify-center gap-2 rounded-full border font-semibold tracking-wide transition-all duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-moss-500 disabled:cursor-not-allowed disabled:opacity-75";
+  "inline-flex items-center justify-center gap-2 rounded-full border font-semibold tracking-wide transition-colors transition-transform duration-subtle ease-[cubic-bezier(0.33,1,0.68,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-moss-500 disabled:cursor-not-allowed disabled:opacity-75 motion-safe:will-change-transform motion-safe:hover:-translate-y-[1px] motion-safe:hover:scale-[1.015] motion-safe:active:translate-y-0 motion-safe:active:scale-100";
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
     "border-transparent bg-moss-600 px-5 text-stone-50 shadow-sm shadow-moss-900/20 hover:bg-moss-700 hover:shadow focus-visible:ring-offset-surface-canvas",
   secondary:
-    "border-moss-200/70 bg-white/80 px-5 text-moss-700 hover:border-moss-300 hover:bg-moss-50/80 focus-visible:ring-offset-surface-canvas",
+    "border-[color:var(--button-secondary-border)] bg-[var(--button-secondary-bg)] px-5 text-[color:var(--button-secondary-color)] hover:border-[color:var(--button-secondary-border-hover)] hover:bg-[color:var(--button-secondary-hover-bg)] focus-visible:ring-offset-surface-canvas",
   ghost:
-    "border-transparent bg-transparent px-4 text-ink hover:bg-ink/5 focus-visible:ring-offset-surface-canvas",
+    "border-transparent bg-transparent px-4 text-[color:var(--color-ink)] hover:bg-[color:var(--button-ghost-hover)] focus-visible:ring-offset-surface-canvas",
 };
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/components/ui/NewsletterForm.tsx
+++ b/components/ui/NewsletterForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
+import { announce } from "@/lib/a11y/announcer";
 import { cn } from "@/lib/utils/cn";
 import { track } from "@/lib/analytics";
 
@@ -79,17 +80,20 @@ export function NewsletterForm({
         const errorMessage = data?.error ?? "We couldn’t save your email just yet. Please try again.";
         setStatus("error");
         setMessage(errorMessage);
+        announce(errorMessage, "assertive");
         return;
       }
 
       setStatus("success");
       setMessage("Success! You’re on the list.");
+      announce("Success! You're on the newsletter list.", "polite");
       track("newsletter_subscribed", { tag, source });
       setEmail("");
     } catch (error) {
       console.error("Newsletter subscription failed", error);
       setStatus("error");
       setMessage("We couldn’t reach the newsletter service. Please try again.");
+      announce("We couldn’t reach the newsletter service. Please try again.", "assertive");
     }
   };
 

--- a/components/ui/Reveal.tsx
+++ b/components/ui/Reveal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, type ComponentPropsWithoutRef, type ElementType, type ReactNode } from "react";
+
+import { cn } from "@/lib/utils/cn";
+
+type RevealProps<T extends ElementType = "div"> = {
+  as?: T;
+  children?: ReactNode;
+  className?: string;
+  delay?: number;
+  once?: boolean;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "className" | "children">;
+
+export function Reveal<T extends ElementType = "div">({
+  as,
+  children,
+  className,
+  delay = 0,
+  once = true,
+  style,
+  ...rest
+}: RevealProps<T>) {
+  const Component = (as ?? "div") as ElementType;
+  const nodeRef = useRef<HTMLElement | null>(null);
+
+  const setNodeRef = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  useEffect(() => {
+    const element = nodeRef.current;
+    if (!element) {
+      return;
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      element.classList.add("is-revealed");
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          entry.target.classList.add("is-revealed");
+          if (once) {
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [once]);
+
+  const computedStyle = useMemo(() => {
+    if (!delay) {
+      return style;
+    }
+
+    const baseStyle = style ? { ...style } : ({} as ComponentPropsWithoutRef<T>["style"]);
+    return { ...baseStyle, transitionDelay: `${delay}ms` } as ComponentPropsWithoutRef<T>["style"];
+  }, [delay, style]);
+
+  return (
+    <Component
+      ref={setNodeRef as never}
+      className={cn("reveal", className)}
+      style={computedStyle}
+      {...(rest as Record<string, unknown>)}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,19 +9,20 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
 
 const toneClasses: Record<NonNullable<CardProps["tone"]>, string> = {
   default:
-    "border-ink/8 bg-white/85 shadow-[0_28px_84px_-48px_rgba(19,34,30,0.45)] backdrop-blur-sm",
-  moss: "border-moss-200/50 bg-moss-50/85 text-ink shadow-[0_24px_72px_-48px_rgba(91,127,107,0.45)]",
-  linen: "border-stone-200/60 bg-stone-50/88 text-ink shadow-[0_20px_68px_-48px_rgba(38,33,28,0.35)]",
+    "border-[color:var(--card-border-default)] bg-[var(--card-bg-default)] text-ink shadow-[var(--card-shadow-default)] backdrop-blur-sm",
+  moss: "border-[color:var(--card-border-moss)] bg-[var(--card-bg-moss)] text-ink shadow-[var(--card-shadow-moss)]",
+  linen: "border-[color:var(--card-border-linen)] bg-[var(--card-bg-linen)] text-ink shadow-[var(--card-shadow-linen)]",
 };
 
 export function Card({ className, tone = "default", interactive = false, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        "group/card relative flex flex-col rounded-3xl border transition-all duration-subtle",
+        "group/card relative flex flex-col rounded-3xl border transition-transform transition-colors duration-subtle ease-[cubic-bezier(0.33,1,0.68,1)]",
+        "motion-safe:will-change-transform",
         toneClasses[tone],
         interactive
-          ? "hover:-translate-y-1 hover:shadow-[0_36px_96px_-56px_rgba(19,34,30,0.55)] focus-within:-translate-y-1 focus-within:shadow-[0_36px_96px_-56px_rgba(19,34,30,0.55)]"
+          ? "motion-safe:hover:-translate-y-[6px] motion-safe:focus-within:-translate-y-[6px] hover:shadow-[0_36px_96px_-56px_rgba(19,34,30,0.55)] focus-within:shadow-[0_36px_96px_-56px_rgba(19,34,30,0.55)]"
           : null,
         className,
       )}

--- a/docs/design-system/implementation-roadmap.md
+++ b/docs/design-system/implementation-roadmap.md
@@ -1,0 +1,35 @@
+# Grounded Living Experience Roadmap
+
+This roadmap outlines how the motion, theming, and visual systems will roll out over the next two months. Each phase builds on
+the previous to maintain stability while layering in richer interaction patterns.
+
+## Phase 1 · Motion & Micro-interactions (Weeks 1–2)
+
+- Ship foundational motion primitives (`Reveal`, `PageTransition`) and wire them through hero, shop, and recipe surfaces.
+- Enhance interactive elements (buttons, cards, nav links) with transform/opacity-based hover and focus states tuned for
+  high-performance rendering.
+- Establish animation guardrails, respecting `prefers-reduced-motion` while precomputing transform layers for smoothness.
+
+## Phase 2 · Dark Mode & Theme Tokens (Weeks 3–4)
+
+- Expand CSS custom properties to cover typography, surfaces, and component tokens for both light and dark palettes.
+- Introduce the header theme toggle with persistence and hydration-safe defaults.
+- Audit contrast against WCAG AA+ targets and document component-level guidance for future features.
+
+## Phase 3 · Advanced Visual Assets (Weeks 5–6)
+
+- Produce reusable OG templates via the edge image renderer, covering editorial and commerce variants.
+- Add infographic modules that Contentful editors can drop into long-form posts, complete with share-ready typography and print
+  treatments.
+- Establish recipe share cards that align with the broader brand system and export cleanly for print or PDF.
+
+## Phase 4 · Mobile QA & Low-end Optimization (Weeks 7–8)
+
+- Perform device lab passes focused on low-end Android with throttled 3G to validate LCP < 2s and CLS < 0.05 targets.
+- Lazy-load non-critical media, reserve CTA slots, and prefetch top-of-fold assets (fonts, hero imagery).
+- Conduct accessibility spot checks for keyboard flow, focus rings, live regions, and announcement timing.
+
+### Ongoing Safeguards
+
+- Monitor Web Vitals via Vercel Speed Insights and surface regressions in weekly design-engineering syncs.
+- Keep interaction specs in sync with the design system so future commerce modules inherit the same motion and theming tokens.

--- a/lib/a11y/announcer.ts
+++ b/lib/a11y/announcer.ts
@@ -1,0 +1,20 @@
+export type PolitenessSetting = "polite" | "assertive";
+
+export interface AnnounceEventDetail {
+  message: string;
+  politeness: PolitenessSetting;
+}
+
+export const ANNOUNCE_EVENT_NAME = "gl:announce";
+
+export function announce(message: string, politeness: PolitenessSetting = "polite"): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const event = new CustomEvent<AnnounceEventDetail>(ANNOUNCE_EVENT_NAME, {
+    detail: { message, politeness },
+  });
+
+  document.dispatchEvent(event);
+}

--- a/lib/richtext.tsx
+++ b/lib/richtext.tsx
@@ -2,7 +2,8 @@ import { Fragment, type ReactNode } from "react";
 
 import Image from "next/image";
 
-import type { RichTextDocument, RichTextMark, RichTextNode } from "@/types/contentful";
+import { InfographicCard } from "@/components/blog/InfographicCard";
+import type { InfographicBlock, RichTextDocument, RichTextMark, RichTextNode } from "@/types/contentful";
 
 import { cn } from "@/lib/utils/cn";
 
@@ -103,6 +104,31 @@ function renderNode(node: RichTextNode, key: string): ReactNode {
           {alt ? <figcaption>{alt}</figcaption> : null}
         </figure>
       );
+    }
+    case "embedded-entry-block": {
+      const target = node.data?.target as { __typename?: string; data?: InfographicBlock } | undefined;
+      if (!target?.__typename || !target.data) {
+        return null;
+      }
+
+      if (target.__typename === "InfographicBlock") {
+        const { data } = target;
+        return (
+          <div key={key} className="not-prose">
+            <InfographicCard
+              id={data.id}
+              eyebrow={data.eyebrow}
+              title={data.title}
+              summary={data.summary}
+              items={data.items}
+              footnote={data.footnote}
+              theme={data.theme ?? "linen"}
+            />
+          </div>
+        );
+      }
+
+      return null;
     }
     case "hyperlink": {
       const uri = typeof node.data?.uri === "string" ? node.data.uri : undefined;

--- a/lib/seo/og.ts
+++ b/lib/seo/og.ts
@@ -1,7 +1,31 @@
 import { siteUrl } from "@/lib/site";
 
-export function ogImageForTitle(title: string): string {
+export interface OgImageOptions {
+  subtitle?: string;
+  eyebrow?: string;
+  tag?: string;
+  variant?: "editorial" | "commerce";
+}
+
+export function ogImageForTitle(title: string, options: OgImageOptions = {}): string {
   const url = new URL("/og", siteUrl);
   url.searchParams.set("title", title);
+
+  if (options.subtitle) {
+    url.searchParams.set("subtitle", options.subtitle);
+  }
+
+  if (options.eyebrow) {
+    url.searchParams.set("eyebrow", options.eyebrow);
+  }
+
+  if (options.tag) {
+    url.searchParams.set("tag", options.tag);
+  }
+
+  if (options.variant) {
+    url.searchParams.set("variant", options.variant);
+  }
+
   return url.toString();
 }

--- a/types/contentful.ts
+++ b/types/contentful.ts
@@ -25,6 +25,7 @@ export interface RichTextNode {
     | "unordered-list"
     | "list-item"
     | "embedded-asset-block"
+    | "embedded-entry-block"
     | "hr"
     | "text";
   value?: string;
@@ -102,6 +103,21 @@ export interface BlogPostRecipe {
   totalTime?: string | number | null;
   ingredients?: string[] | null;
   instructions?: string[] | null;
+}
+
+export interface InfographicListItem {
+  title: string;
+  description?: string | null;
+}
+
+export interface InfographicBlock {
+  id: string;
+  eyebrow?: string | null;
+  title: string;
+  summary?: string | null;
+  items: InfographicListItem[];
+  footnote?: string | null;
+  theme?: "moss" | "spruce" | "saffron" | "linen";
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a reusable infographic card component, styling tokens, and render support for Contentful embedded entries
- create a printable recipe card component and promote featured cards on the recipes landing page with refreshed CSS
- preload hero assets, document the motion roadmap, and update carousel accessibility along with Contentful enrichments

## Testing
- npm run lint
- npm run typecheck
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7733663ac832fb05feef1483c61d3