### PR TITLE
Fix: disable canonical redirect on Vercel domains

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -43,6 +43,13 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  if (normalizedHost.endsWith(".vercel.app")) {
+    // Allow Vercel preview/production domains to serve content directly without forcing the
+    // canonical custom domain. This ensures groundedlivingorg.vercel.app remains usable when
+    // the custom domain is not configured in the Vercel project.
+    return NextResponse.next();
+  }
+
   if (process.env.NODE_ENV !== "production" && !normalizedHost.endsWith(".vercel.app")) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
- allow the middleware to skip canonical redirects when requests come from a `.vercel.app` host so preview/production Vercel URLs remain accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8086033f0832fa4ef1925a82a5a1d